### PR TITLE
Implements backend API support for user creation

### DIFF
--- a/infra/scoped/api-gateway.tf
+++ b/infra/scoped/api-gateway.tf
@@ -278,7 +278,7 @@ resource "aws_api_gateway_method" "users_post" {
   request_validator_id = aws_api_gateway_request_validator.full.id
 
   request_models = {
-    "application/json" = aws_api_gateway_model.user.name
+    "application/json" = aws_api_gateway_model.create-user.name
   }
 }
 
@@ -499,7 +499,7 @@ resource "aws_api_gateway_method" "users_userid_put" {
   request_validator_id = aws_api_gateway_request_validator.full.id
 
   request_models = {
-    "application/json" = aws_api_gateway_model.user.name
+    "application/json" = aws_api_gateway_model.update-user.name
   }
 
   request_parameters = {

--- a/infra/scoped/api-model.tf
+++ b/infra/scoped/api-model.tf
@@ -24,3 +24,17 @@ resource "aws_api_gateway_model" "user-list" {
   content_type = "application/json"
   schema       = file("${path.module}/../../models/user-list.json")
 }
+
+resource "aws_api_gateway_model" "create-user" {
+  name         = "CreateUser"
+  rest_api_id  = aws_api_gateway_rest_api.identity.id
+  content_type = "application/json"
+  schema       = file("${path.module}/../../models/create-user.json")
+}
+
+resource "aws_api_gateway_model" "update-user" {
+  name         = "UpdateUser"
+  rest_api_id  = aws_api_gateway_rest_api.identity.id
+  content_type = "application/json"
+  schema       = file("${path.module}/../../models/update-user.json")
+}

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -79,7 +79,7 @@ resource "auth0_client_grant" "buildkite" {
 }
 
 resource "auth0_client" "api_gateway_identity" {
-  name     = "Identity API Gateway ${terraform.workspace}"
+  name     = "Identity Lambda API (${terraform.workspace})"
   app_type = "non_interactive"
 
   custom_login_page_on = false

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -90,6 +90,7 @@ resource "auth0_client_grant" "api_gateway_identity" {
   audience  = "https://${aws_ssm_parameter.auth0_domain.value}/api/v2/"
   scope = [
     "read:users",
-    "read:user_idp_tokens"
+    "read:user_idp_tokens",
+    "create:users"
   ]
 }

--- a/infra/scoped/auth0-database.tf
+++ b/infra/scoped/auth0-database.tf
@@ -3,6 +3,7 @@ resource "auth0_connection" "sierra" {
   strategy = "auth0"
 
   enabled_clients = [
+    auth0_client.api_gateway_identity.id, # Required to allow the Lambda API client credentials to operate on the connection
     auth0_client.dummy_test.id
   ]
 
@@ -16,7 +17,7 @@ resource "auth0_connection" "sierra" {
 
     password_history {
       enable = false
-      size   = 0
+      size   = 5 # Even though we don't use it, this can't be zero - set it to the default value of 5
     }
 
     password_no_personal_info {

--- a/infra/scoped/auth0-email.tf
+++ b/infra/scoped/auth0-email.tf
@@ -1,11 +1,12 @@
 resource "auth0_email" "email" {
-  name                 = "ses"
+  name                 = "smtp"
   enabled              = true
   default_from_address = "${aws_ssm_parameter.auth0_email_from_name.value} <${data.aws_ssm_parameter.auth0_email_from_user.value}@${data.aws_ssm_parameter.auth0_email_from_domain.value}>"
 
   credentials {
-    access_key_id     = aws_iam_access_key.auth0_email.id
-    secret_access_key = aws_iam_access_key.auth0_email.secret
-    region            = "eu-west-1"
+    smtp_host = "email-smtp.eu-west-1.amazonaws.com"
+    smtp_port = 587
+    smtp_user = aws_iam_access_key.auth0_email.id
+    smtp_pass = aws_iam_access_key.auth0_email.ses_smtp_password_v4
   }
 }

--- a/infra/scoped/lambda.tf
+++ b/infra/scoped/lambda.tf
@@ -53,6 +53,7 @@ resource "aws_lambda_function" "api" {
   role          = aws_iam_role.identity_api_gateway_lambda_role.arn
   runtime       = "nodejs12.x"
   filename      = "data/empty.zip"
+  timeout       = 10
 
   environment {
     variables = {

--- a/models/create-user.json
+++ b/models/create-user.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Create User Schema",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "firstName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lastName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "password": {
+      "type": "string",
+      "minLength": 1
+    }
+    },
+  "required": [
+    "title",
+    "firstName",
+    "lastName",
+    "email",
+    "password"
+  ],
+  "additionalProperties": false
+}

--- a/models/update-user.json
+++ b/models/update-user.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Update User Schema",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    }
+  },
+  "required": [
+    "title",
+    "email"
+  ],
+  "additionalProperties": false
+}

--- a/packages/apps/api-authorizer/src/index.ts
+++ b/packages/apps/api-authorizer/src/index.ts
@@ -76,7 +76,7 @@ function validateRequest(auth0UserInfo: Auth0UserInfo, pathParameters: { [name: 
   return false;
 }
 
-function buildAuthorizerResult(principal: string | number, effect: string, methodArn: string): APIGatewayAuthorizerResult {
+function buildAuthorizerResult(principal: string | bigint, effect: string, methodArn: string): APIGatewayAuthorizerResult {
   return {
     principalId: principal.toString(),
     policyDocument: {

--- a/packages/apps/api-authorizer/src/index.ts
+++ b/packages/apps/api-authorizer/src/index.ts
@@ -76,7 +76,7 @@ function validateRequest(auth0UserInfo: Auth0UserInfo, pathParameters: { [name: 
   return false;
 }
 
-function buildAuthorizerResult(principal: string | bigint, effect: string, methodArn: string): APIGatewayAuthorizerResult {
+function buildAuthorizerResult(principal: string | number, effect: string, methodArn: string): APIGatewayAuthorizerResult {
   return {
     principalId: principal.toString(),
     policyDocument: {

--- a/packages/apps/api/src/app.ts
+++ b/packages/apps/api/src/app.ts
@@ -4,7 +4,7 @@ import bodyParser from 'body-parser';
 import cors from 'cors';
 import express, { Application, Request, Response } from 'express';
 import { validateCredentials } from './handlers/auth';
-import { getUser } from './handlers/user';
+import { createUser, getUser } from './handlers/user';
 import { DummyUserOne, DummyUserTwo } from './models/user';
 
 export default createApplication();
@@ -53,7 +53,7 @@ function registerUsersResource(app: Application): void {
   }
   app.options('/users', cors(corsOptions));
   app.get('/users', cors(corsOptions), (request: Request, response: Response) => response.status(200).json([DummyUserOne, DummyUserTwo]));
-  app.post('/users', cors(corsOptions), (request: Request, response: Response) => response.status(201).json(DummyUserOne));
+  app.post('/users', cors(corsOptions), (request: Request, response: Response) => createUser(sierraClient, auth0Client, request, response));
 }
 
 function registerUsersUserIdResource(app: Application): void {

--- a/packages/apps/api/src/handlers/auth.ts
+++ b/packages/apps/api/src/handlers/auth.ts
@@ -1,15 +1,15 @@
-import {APIResponse, ResponseStatus} from '@weco/identity-common';
+import { APIResponse, isNonBlank, ResponseStatus } from '@weco/identity-common';
 import SierraClient from '@weco/sierra-client';
-import {Request, Response} from 'express';
-import {toMessage} from '../models/common';
-import {PatronRecord} from "@weco/sierra-client/lib/patron";
+import { PatronRecord } from "@weco/sierra-client/lib/patron";
+import { Request, Response } from 'express';
+import { toMessage } from '../models/common';
 
 export async function validateCredentials(sierraClient: SierraClient, request: Request, response: Response): Promise<void> {
 
   const email = request.body.email;
   const password = request.body.password;
 
-  if (!email || !password) {
+  if (!isNonBlank(email) || !isNonBlank(password)) {
     response.status(400).json(toMessage("All fields must be provided and non-blank"));
   }
 

--- a/packages/apps/api/src/handlers/auth.ts
+++ b/packages/apps/api/src/handlers/auth.ts
@@ -13,9 +13,9 @@ export async function validateCredentials(sierraClient: SierraClient, request: R
     response.status(400).json(toMessage("All fields must be provided and non-blank"));
   }
 
-  const sierraGet: APIResponse<PatronRecord> = await sierraClient.getPatronRecordByEmail(request.body.email);
+  const sierraGet: APIResponse<PatronRecord> = await sierraClient.getPatronRecordByEmail(email);
   if (sierraGet.status === ResponseStatus.Success) {
-    const sierraValidate: APIResponse<{}> = await sierraClient.validateCredentials(sierraGet.result.barcode, request.body.password);
+    const sierraValidate: APIResponse<{}> = await sierraClient.validateCredentials(sierraGet.result.barcode, password);
     if (sierraValidate.status === ResponseStatus.Success) {
       response.status(200).end();
     } else if (sierraValidate.status === ResponseStatus.InvalidCredentials) {

--- a/packages/apps/api/src/handlers/auth.ts
+++ b/packages/apps/api/src/handlers/auth.ts
@@ -1,24 +1,31 @@
-import { ResponseStatus } from '@weco/identity-common';
+import {APIResponse, ResponseStatus} from '@weco/identity-common';
 import SierraClient from '@weco/sierra-client';
-import { Request, Response } from 'express';
-import { toMessage } from '../models/common';
+import {Request, Response} from 'express';
+import {toMessage} from '../models/common';
+import {PatronRecord} from "@weco/sierra-client/lib/patron";
 
-export async function validateCredentials(sierraClient: SierraClient, req: Request, res: Response): Promise<void> {
-  sierraClient.getPatronRecordByEmail(req.body.email).then(response => {
-    if (response.status === ResponseStatus.Success) {
-      sierraClient.validateCredentials(response.result.barcode, req.body.password).then(response => {
-        if (response.status === ResponseStatus.Success) {
-          res.status(200).end();
-        } else if (response.status === ResponseStatus.InvalidCredentials) {
-          res.status(401).json(toMessage(response.message));
-        } else {
-          res.status(500).json(toMessage(response.message));
-        }
-      });
-    } else if (response.status === ResponseStatus.NotFound) {
-      res.status(404).json(toMessage(response.message))
+export async function validateCredentials(sierraClient: SierraClient, request: Request, response: Response): Promise<void> {
+
+  const email = request.body.email;
+  const password = request.body.password;
+
+  if (!email || !password) {
+    response.status(400).json(toMessage("All fields must be provided and non-blank"));
+  }
+
+  const sierraGet: APIResponse<PatronRecord> = await sierraClient.getPatronRecordByEmail(request.body.email);
+  if (sierraGet.status === ResponseStatus.Success) {
+    const sierraValidate: APIResponse<{}> = await sierraClient.validateCredentials(sierraGet.result.barcode, request.body.password);
+    if (sierraValidate.status === ResponseStatus.Success) {
+      response.status(200).end();
+    } else if (sierraValidate.status === ResponseStatus.InvalidCredentials) {
+      response.status(401).json(toMessage(sierraValidate.message));
     } else {
-      res.status(500).json(toMessage(response.message));
+      response.status(500).json(toMessage(sierraValidate.message));
     }
-  });
+  } else if (sierraGet.status === ResponseStatus.NotFound) {
+    response.status(404).json(toMessage(sierraGet.message))
+  } else {
+    response.status(500).json(toMessage(sierraGet.message));
+  }
 }

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -28,31 +28,39 @@ export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Clie
 export async function createUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
   return sierraClient.getPatronRecordByEmail(request.body.email).then(sierraResponse => {
     if (sierraResponse.status === ResponseStatus.NotFound) {
-      return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.password).then(sierraResponse => {
-        if (sierraResponse.status === ResponseStatus.Success) {
-          return auth0Client.createUser(sierraResponse.result, request.body.email, request.body.password).then(auth0Response => {
-            if (auth0Response.status === ResponseStatus.Success) {
-              return sierraClient.addPostCreationFields(sierraResponse.result, request.body.email).then(sierraResponse => {
-                if (sierraResponse.status === ResponseStatus.Success) {
-                  response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
-                } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
-                  response.status(400).json(toMessage(sierraResponse.message));
+      auth0Client.getProfileByEmail(request.body.email).then(auth0Response => {
+        if (auth0Response.status === ResponseStatus.NotFound) {
+          return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.password).then(sierraResponse => {
+            if (sierraResponse.status === ResponseStatus.Success) {
+              return auth0Client.createUser(sierraResponse.result, request.body.email, request.body.password).then(auth0Response => {
+                if (auth0Response.status === ResponseStatus.Success) {
+                  return sierraClient.addPostCreationFields(sierraResponse.result, request.body.email).then(sierraResponse => {
+                    if (sierraResponse.status === ResponseStatus.Success) {
+                      response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
+                    } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
+                      response.status(400).json(toMessage(sierraResponse.message));
+                    } else {
+                      response.status(500).json(toMessage(sierraResponse.message));
+                    }
+                  });
+                } else if (auth0Response.status === ResponseStatus.MalformedRequest) {
+                  response.status(400).json(toMessage(auth0Response.message));
+                } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {
+                  response.status(409).json(toMessage(auth0Response.message));
                 } else {
-                  response.status(500).json(toMessage(sierraResponse.message));
+                  response.status(500).json(toMessage(auth0Response.message));
                 }
               });
-            } else if (auth0Response.status === ResponseStatus.MalformedRequest) {
-              response.status(400).json(toMessage(auth0Response.message));
-            } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {
-              response.status(409).json(toMessage(auth0Response.message));
+            } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
+              response.status(400).json(toMessage(sierraResponse.message));
             } else {
-              response.status(500).json(toMessage(auth0Response.message));
+              response.status(500).json(toMessage(sierraResponse.message));
             }
           });
-        } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
-          response.status(400).json(toMessage(sierraResponse.message));
+        } else if (auth0Response.status === ResponseStatus.Success) {
+          response.status(409).json(toMessage('Auth0 user with email [' + request.body.email + '] already exists'));
         } else {
-          response.status(500).json(toMessage(sierraResponse.message));
+          response.status(500).json(toMessage(auth0Response.message));
         }
       });
     } else if (sierraResponse.status === ResponseStatus.Success) {

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -32,9 +32,9 @@ export async function createUser(sierraClient: SierraClient, auth0Client: Auth0C
         if (auth0Response.status === ResponseStatus.NotFound) {
           return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.password).then(sierraResponse => {
             if (sierraResponse.status === ResponseStatus.Success) {
-              return auth0Client.createAccount(sierraResponse.result, request.body.email, request.body.password).then(auth0Response => {
+              return auth0Client.createUser(sierraResponse.result, request.body.email, request.body.password).then(auth0Response => {
                 if (auth0Response.status === ResponseStatus.Success) {
-                  return sierraClient.updatePatronRecord(sierraResponse.result, request.body.email).then(sierraResponse => {
+                  return sierraClient.addPostCreationFields(sierraResponse.result, request.body.email).then(sierraResponse => {
                     if (sierraResponse.status === ResponseStatus.Success) {
                       response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
                     } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -1,10 +1,9 @@
 import Auth0Client from '@weco/auth0-client';
 import { Auth0Profile } from "@weco/auth0-client/lib/auth0";
-import { APIResponse, ResponseStatus } from '@weco/identity-common';
+import { APIResponse, isNonBlank, ResponseStatus } from '@weco/identity-common';
 import SierraClient from '@weco/sierra-client';
 import { PatronRecord } from "@weco/sierra-client/lib/patron";
 import { Request, Response } from 'express';
-import { isNonBlank } from "../../../../shared/identity-common/src";
 import { toMessage } from '../models/common';
 import { toUser } from '../models/user';
 

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -26,7 +26,7 @@ export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Clie
 }
 
 export async function createUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
-  return sierraClient.getPatronRecordByEmail(request.params.email).then(sierraResponse => {
+  return sierraClient.getPatronRecordByEmail(request.body.email).then(sierraResponse => {
     if (sierraResponse.status === ResponseStatus.NotFound) {
       return auth0Client.createAccount(request.body.email, request.body.password).then(auth0Response => {
         if (auth0Response.status === ResponseStatus.Success) {

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -28,39 +28,31 @@ export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Clie
 export async function createUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
   return sierraClient.getPatronRecordByEmail(request.body.email).then(sierraResponse => {
     if (sierraResponse.status === ResponseStatus.NotFound) {
-      auth0Client.getProfileByEmail(request.body.email).then(auth0Response => {
-        if (auth0Response.status === ResponseStatus.NotFound) {
-          return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.password).then(sierraResponse => {
-            if (sierraResponse.status === ResponseStatus.Success) {
-              return auth0Client.createUser(sierraResponse.result, request.body.email, request.body.password).then(auth0Response => {
-                if (auth0Response.status === ResponseStatus.Success) {
-                  return sierraClient.addPostCreationFields(sierraResponse.result, request.body.email).then(sierraResponse => {
-                    if (sierraResponse.status === ResponseStatus.Success) {
-                      response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
-                    } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
-                      response.status(400).json(toMessage(sierraResponse.message));
-                    } else {
-                      response.status(500).json(toMessage(sierraResponse.message));
-                    }
-                  });
-                } else if (auth0Response.status === ResponseStatus.MalformedRequest) {
-                  response.status(400).json(toMessage(auth0Response.message));
-                } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {
-                  response.status(409).json(toMessage(auth0Response.message));
+      return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.password).then(sierraResponse => {
+        if (sierraResponse.status === ResponseStatus.Success) {
+          return auth0Client.createUser(sierraResponse.result, request.body.email, request.body.password).then(auth0Response => {
+            if (auth0Response.status === ResponseStatus.Success) {
+              return sierraClient.addPostCreationFields(sierraResponse.result, request.body.email).then(sierraResponse => {
+                if (sierraResponse.status === ResponseStatus.Success) {
+                  response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
+                } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
+                  response.status(400).json(toMessage(sierraResponse.message));
                 } else {
-                  response.status(500).json(toMessage(auth0Response.message));
+                  response.status(500).json(toMessage(sierraResponse.message));
                 }
               });
-            } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
-              response.status(400).json(toMessage(sierraResponse.message));
+            } else if (auth0Response.status === ResponseStatus.MalformedRequest) {
+              response.status(400).json(toMessage(auth0Response.message));
+            } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {
+              response.status(409).json(toMessage(auth0Response.message));
             } else {
-              response.status(500).json(toMessage(sierraResponse.message));
+              response.status(500).json(toMessage(auth0Response.message));
             }
           });
-        } else if (auth0Response.status === ResponseStatus.Success) {
-          response.status(409).json(toMessage('Auth0 user with email [' + request.body.email + '] already exists'));
+        } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
+          response.status(400).json(toMessage(sierraResponse.message));
         } else {
-          response.status(500).json(toMessage(auth0Response.message));
+          response.status(500).json(toMessage(sierraResponse.message));
         }
       });
     } else if (sierraResponse.status === ResponseStatus.Success) {

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -1,11 +1,12 @@
 import Auth0Client from '@weco/auth0-client';
-import {APIResponse, ResponseStatus} from '@weco/identity-common';
+import { Auth0Profile } from "@weco/auth0-client/lib/auth0";
+import { APIResponse, ResponseStatus } from '@weco/identity-common';
 import SierraClient from '@weco/sierra-client';
-import {Request, Response} from 'express';
-import {toMessage} from '../models/common';
-import {toUser} from '../models/user';
-import {PatronRecord} from "@weco/sierra-client/lib/patron";
-import {Auth0Profile} from "@weco/auth0-client/lib/auth0";
+import { PatronRecord } from "@weco/sierra-client/lib/patron";
+import { Request, Response } from 'express';
+import { isNonBlank } from "../../../../shared/identity-common/src";
+import { toMessage } from '../models/common';
+import { toUser } from '../models/user';
 
 export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
 
@@ -39,7 +40,7 @@ export async function createUser(sierraClient: SierraClient, auth0Client: Auth0C
   const email: string = request.body.email;
   const password: string = request.body.password;
 
-  if (!title || !firstName || !lastName || !email || !password) {
+  if (!isNonBlank(title) || !isNonBlank(firstName) || !isNonBlank(lastName) || !isNonBlank(email) || !isNonBlank(password)) {
     response.status(400).json(toMessage("All fields must be provided and non-blank"));
   }
 

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -1,9 +1,9 @@
 import Auth0Client from '@weco/auth0-client';
-import { ResponseStatus } from '@weco/identity-common';
+import {ResponseStatus} from '@weco/identity-common';
 import SierraClient from '@weco/sierra-client';
-import { Request, Response } from 'express';
-import { toMessage } from '../models/common';
-import { toUser } from '../models/user';
+import {Request, Response} from 'express';
+import {toMessage} from '../models/common';
+import {toUser} from '../models/user';
 
 export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
   return sierraClient.getPatronRecordByRecordNumber(Number(request.params.user_id)).then(sierraResponse => {
@@ -30,11 +30,19 @@ export async function createUser(sierraClient: SierraClient, auth0Client: Auth0C
     if (sierraResponse.status === ResponseStatus.NotFound) {
       auth0Client.getProfileByEmail(request.body.email).then(auth0Response => {
         if (auth0Response.status === ResponseStatus.NotFound) {
-          return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.email, request.body.password).then(sierraResponse => {
+          return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.password).then(sierraResponse => {
             if (sierraResponse.status === ResponseStatus.Success) {
-              return auth0Client.createAccount(request.body.email, request.body.password).then(auth0Response => {
+              return auth0Client.createAccount(sierraResponse.result, request.body.email, request.body.password).then(auth0Response => {
                 if (auth0Response.status === ResponseStatus.Success) {
-                  response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
+                  return sierraClient.updatePatronRecord(sierraResponse.result, request.body.email).then(sierraResponse => {
+                    if (sierraResponse.status === ResponseStatus.Success) {
+                      response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
+                    } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
+                      response.status(400).json(toMessage(sierraResponse.message));
+                    } else {
+                      response.status(500).json(toMessage(sierraResponse.message));
+                    }
+                  });
                 } else if (auth0Response.status === ResponseStatus.MalformedRequest) {
                   response.status(400).json(toMessage(auth0Response.message));
                 } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -1,9 +1,9 @@
 import Auth0Client from '@weco/auth0-client';
-import {ResponseStatus} from '@weco/identity-common';
+import { ResponseStatus } from '@weco/identity-common';
 import SierraClient from '@weco/sierra-client';
-import {Request, Response} from 'express';
-import {toMessage} from '../models/common';
-import {toUser} from '../models/user';
+import { Request, Response } from 'express';
+import { toMessage } from '../models/common';
+import { toUser } from '../models/user';
 
 export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
   return sierraClient.getPatronRecordByRecordNumber(Number(request.params.user_id)).then(sierraResponse => {
@@ -28,29 +28,35 @@ export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Clie
 export async function createUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
   return sierraClient.getPatronRecordByEmail(request.body.email).then(sierraResponse => {
     if (sierraResponse.status === ResponseStatus.NotFound) {
-      return auth0Client.createAccount(request.body.email, request.body.password).then(auth0Response => {
-        if (auth0Response.status === ResponseStatus.Success) {
+      auth0Client.getProfileByEmail(request.body.email).then(auth0Response => {
+        if (auth0Response.status === ResponseStatus.NotFound) {
           return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.email, request.body.password).then(sierraResponse => {
             if (sierraResponse.status === ResponseStatus.Success) {
-              response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
-            } else if (sierraResponse.status === ResponseStatus.UserAlreadyExists) {
-              response.status(409).json(toMessage(sierraResponse.message));
+              return auth0Client.createAccount(request.body.email, request.body.password).then(auth0Response => {
+                if (auth0Response.status === ResponseStatus.Success) {
+                  response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
+                } else if (auth0Response.status === ResponseStatus.MalformedRequest) {
+                  response.status(400).json(toMessage(auth0Response.message));
+                } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {
+                  response.status(409).json(toMessage(auth0Response.message));
+                } else {
+                  response.status(500).json(toMessage(auth0Response.message));
+                }
+              });
             } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
               response.status(400).json(toMessage(sierraResponse.message));
             } else {
               response.status(500).json(toMessage(sierraResponse.message));
             }
           });
-        } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {
-          response.status(409).json(toMessage(auth0Response.message));
-        } else if (auth0Response.status === ResponseStatus.MalformedRequest) {
-          response.status(400).json(toMessage(auth0Response.message));
+        } else if (auth0Response.status === ResponseStatus.Success) {
+          response.status(409).json(toMessage('Auth0 user with email [' + request.body.email + '] already exists'));
         } else {
           response.status(500).json(toMessage(auth0Response.message));
         }
       });
     } else if (sierraResponse.status === ResponseStatus.Success) {
-      response.status(409).json(toMessage('Patron Record with email [' + request.params.email + '] already exists'));
+      response.status(409).json(toMessage('Patron record with email [' + request.body.email + '] already exists'));
     } else {
       response.status(500).json(toMessage(sierraResponse.message));
     }

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -5,22 +5,50 @@ import { Request, Response } from 'express';
 import { toMessage } from '../models/common';
 import { toUser } from '../models/user';
 
-export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Client, req: Request, res: Response): Promise<void> {
-  return sierraClient.getPatronRecordByRecordNumber(req.params.user_id).then(sierraResponse => {
+export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
+  return sierraClient.getPatronRecordByRecordNumber(BigInt(request.params.user_id)).then(sierraResponse => {
     if (sierraResponse.status === ResponseStatus.Success) {
-      auth0Client.getProfile(req.params.user_id).then(auth0Response => {
+      return auth0Client.getProfileByUserId(request.params.user_id).then(auth0Response => {
         if (auth0Response.status === ResponseStatus.Success) {
-          res.status(200).json(toUser(sierraResponse.result, auth0Response.result));
+          response.status(200).json(toUser(sierraResponse.result, auth0Response.result));
         } else if (auth0Response.status === ResponseStatus.NotFound) {
-          res.status(404).json(toMessage(auth0Response.message));
+          response.status(404).json(toMessage(auth0Response.message));
         } else {
-          res.status(500).json(toMessage(auth0Response.message));
+          response.status(500).json(toMessage(auth0Response.message));
         }
       });
     } else if (sierraResponse.status == ResponseStatus.NotFound) {
-      res.status(404).json(toMessage(sierraResponse.message));
+      response.status(404).json(toMessage(sierraResponse.message));
     } else {
-      res.status(500).json(toMessage(sierraResponse.message));
+      response.status(500).json(toMessage(sierraResponse.message));
+    }
+  });
+}
+
+export async function createUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
+  return sierraClient.getPatronRecordByEmail(request.params.email).then(sierraResponse => {
+    if (sierraResponse.status === ResponseStatus.NotFound) {
+      return auth0Client.createAccount(request.body.email, request.body.password).then(auth0Response => {
+        if (auth0Response.status === ResponseStatus.Success) {
+          return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.email, request.body.password).then(sierraResponse => {
+            if (sierraResponse.status === ResponseStatus.Success) {
+              response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
+            } else if (sierraResponse.status === ResponseStatus.UserAlreadyExists) {
+              response.status(409).json(toMessage(sierraResponse.message));
+            } else {
+              response.status(500).json(toMessage(sierraResponse.message));
+            }
+          });
+        } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {
+          response.status(409).json(toMessage(auth0Response.message));
+        } else {
+          response.status(500).json(toMessage(auth0Response.message));
+        }
+      });
+    } else if (sierraResponse.status === ResponseStatus.Success) {
+      response.status(409).json(toMessage('Patron Record with email [' + request.params.email + '] already exists'));
+    } else {
+      response.status(500).json(toMessage(sierraResponse.message));
     }
   });
 }

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -44,9 +44,9 @@ export async function createUser(sierraClient: SierraClient, auth0Client: Auth0C
     response.status(400).json(toMessage("All fields must be provided and non-blank"));
   }
 
-  const sierraGet: APIResponse<PatronRecord> = await sierraClient.getPatronRecordByEmail(request.body.email);
+  const sierraGet: APIResponse<PatronRecord> = await sierraClient.getPatronRecordByEmail(email);
   if (sierraGet.status === ResponseStatus.NotFound) {
-    const auth0Get: APIResponse<Auth0Profile> = await auth0Client.getUserByEmail(request.body.email);
+    const auth0Get: APIResponse<Auth0Profile> = await auth0Client.getUserByEmail(email);
     if (auth0Get.status === ResponseStatus.NotFound) {
       const sierraCreate: APIResponse<number> = await sierraClient.createPatronRecord(title, firstName, lastName, password);
       if (sierraCreate.status === ResponseStatus.Success) {
@@ -73,12 +73,12 @@ export async function createUser(sierraClient: SierraClient, auth0Client: Auth0C
         response.status(500).json(toMessage(sierraCreate.message));
       }
     } else if (auth0Get.status === ResponseStatus.Success) {
-      response.status(409).json(toMessage('Auth0 user with email [' + request.body.email + '] already exists'));
+      response.status(409).json(toMessage('Auth0 user with email [' + email + '] already exists'));
     } else {
       response.status(500).json(toMessage(auth0Get.message));
     }
   } else if (sierraGet.status === ResponseStatus.Success) {
-    response.status(409).json(toMessage('Patron record with email [' + request.body.email + '] already exists'));
+    response.status(409).json(toMessage('Patron record with email [' + email + '] already exists'));
   } else {
     response.status(500).json(toMessage(sierraGet.message));
   }

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -1,74 +1,84 @@
 import Auth0Client from '@weco/auth0-client';
-import {ResponseStatus} from '@weco/identity-common';
+import {APIResponse, ResponseStatus} from '@weco/identity-common';
 import SierraClient from '@weco/sierra-client';
 import {Request, Response} from 'express';
 import {toMessage} from '../models/common';
 import {toUser} from '../models/user';
+import {PatronRecord} from "@weco/sierra-client/lib/patron";
+import {Auth0Profile} from "@weco/auth0-client/lib/auth0";
 
 export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
-  return sierraClient.getPatronRecordByRecordNumber(Number(request.params.user_id)).then(sierraResponse => {
-    if (sierraResponse.status === ResponseStatus.Success) {
-      return auth0Client.getProfileByUserId(request.params.user_id).then(auth0Response => {
-        if (auth0Response.status === ResponseStatus.Success) {
-          response.status(200).json(toUser(sierraResponse.result, auth0Response.result));
-        } else if (auth0Response.status === ResponseStatus.NotFound) {
-          response.status(404).json(toMessage(auth0Response.message));
-        } else {
-          response.status(500).json(toMessage(auth0Response.message));
-        }
-      });
-    } else if (sierraResponse.status == ResponseStatus.NotFound) {
-      response.status(404).json(toMessage(sierraResponse.message));
+
+  const userId: number = Number(request.params.user_id);
+  if (isNaN(userId)) {
+    response.status(400).json(toMessage('Invalid user ID [' + userId + ']'));
+  }
+
+  const sierraGet: APIResponse<PatronRecord> = await sierraClient.getPatronRecordByRecordNumber(userId);
+  if (sierraGet.status === ResponseStatus.Success) {
+    const auth0Get: APIResponse<Auth0Profile> = await auth0Client.getUserByUserId(userId);
+    if (auth0Get.status === ResponseStatus.Success) {
+      response.status(200).json(toUser(sierraGet.result, auth0Get.result));
+    } else if (auth0Get.status === ResponseStatus.NotFound) {
+      response.status(404).json(toMessage(auth0Get.message));
     } else {
-      response.status(500).json(toMessage(sierraResponse.message));
+      response.status(500).json(toMessage(auth0Get.message));
     }
-  });
+  } else if (sierraGet.status === ResponseStatus.NotFound) {
+    response.status(404).json(toMessage(sierraGet.message));
+  } else {
+    response.status(500).json(toMessage(sierraGet.message));
+  }
 }
 
 export async function createUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
-  const sierraCheck = sierraClient.getPatronRecordByEmail(request.body.email);
-  const auth0Check = auth0Client.getProfileByEmail(request.body.email);
-  sierraCheck.then(sierraResponse => {
-    if (sierraResponse.status === ResponseStatus.NotFound) {
-      auth0Check.then(auth0Response => {
-        if (auth0Response.status === ResponseStatus.NotFound) {
-          return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.password).then(sierraResponse => {
-            if (sierraResponse.status === ResponseStatus.Success) {
-              return auth0Client.createUser(sierraResponse.result, request.body.email, request.body.password).then(auth0Response => {
-                if (auth0Response.status === ResponseStatus.Success) {
-                  return sierraClient.addPostCreationFields(sierraResponse.result, request.body.email).then(sierraResponse => {
-                    if (sierraResponse.status === ResponseStatus.Success) {
-                      response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
-                    } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
-                      response.status(400).json(toMessage(sierraResponse.message));
-                    } else {
-                      response.status(500).json(toMessage(sierraResponse.message));
-                    }
-                  });
-                } else if (auth0Response.status === ResponseStatus.MalformedRequest) {
-                  response.status(400).json(toMessage(auth0Response.message));
-                } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {
-                  response.status(409).json(toMessage(auth0Response.message));
-                } else {
-                  response.status(500).json(toMessage(auth0Response.message));
-                }
-              });
-            } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
-              response.status(400).json(toMessage(sierraResponse.message));
-            } else {
-              response.status(500).json(toMessage(sierraResponse.message));
-            }
-          });
-        } else if (auth0Response.status === ResponseStatus.Success) {
-          response.status(409).json(toMessage('Auth0 user with email [' + request.body.email + '] already exists'));
+
+  const title: string = request.body.title;
+  const firstName: string = request.body.firstName;
+  const lastName: string = request.body.lastName;
+  const email: string = request.body.email;
+  const password: string = request.body.password;
+
+  if (!title || !firstName || !lastName || !email || !password) {
+    response.status(400).json(toMessage("All fields must be provided and non-blank"));
+  }
+
+  const sierraGet: APIResponse<PatronRecord> = await sierraClient.getPatronRecordByEmail(request.body.email);
+  if (sierraGet.status === ResponseStatus.NotFound) {
+    const auth0Get: APIResponse<Auth0Profile> = await auth0Client.getUserByEmail(request.body.email);
+    if (auth0Get.status === ResponseStatus.NotFound) {
+      const sierraCreate: APIResponse<number> = await sierraClient.createPatronRecord(title, firstName, lastName, password);
+      if (sierraCreate.status === ResponseStatus.Success) {
+        const auth0Create: APIResponse<Auth0Profile> = await auth0Client.createUser(sierraCreate.result, email, password);
+        if (auth0Create.status === ResponseStatus.Success) {
+          const sierraUpdate: APIResponse<PatronRecord> = await sierraClient.updatePatronPostCreationFields(sierraCreate.result, email);
+          if (sierraUpdate.status === ResponseStatus.Success) {
+            response.status(201).json(toUser(sierraUpdate.result, auth0Create.result));
+          } else if (sierraUpdate.status === ResponseStatus.MalformedRequest) {
+            response.status(400).json(toMessage(sierraUpdate.message));
+          } else {
+            response.status(500).json(toMessage(sierraUpdate.message));
+          }
+        } else if (auth0Create.status === ResponseStatus.MalformedRequest) {
+          response.status(400).json(toMessage(auth0Create.message));
+        } else if (auth0Create.status === ResponseStatus.UserAlreadyExists) {
+          response.status(409).json(toMessage(auth0Create.message));
         } else {
-          response.status(500).json(toMessage(auth0Response.message));
+          response.status(500).json(toMessage(auth0Create.message));
         }
-      });
-    } else if (sierraResponse.status === ResponseStatus.Success) {
-      response.status(409).json(toMessage('Patron record with email [' + request.body.email + '] already exists'));
+      } else if (sierraCreate.status === ResponseStatus.MalformedRequest) {
+        response.status(400).json(toMessage(sierraCreate.message));
+      } else {
+        response.status(500).json(toMessage(sierraCreate.message));
+      }
+    } else if (auth0Get.status === ResponseStatus.Success) {
+      response.status(409).json(toMessage('Auth0 user with email [' + request.body.email + '] already exists'));
     } else {
-      response.status(500).json(toMessage(sierraResponse.message));
+      response.status(500).json(toMessage(auth0Get.message));
     }
-  });
+  } else if (sierraGet.status === ResponseStatus.Success) {
+    response.status(409).json(toMessage('Patron record with email [' + request.body.email + '] already exists'));
+  } else {
+    response.status(500).json(toMessage(sierraGet.message));
+  }
 }

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -26,9 +26,11 @@ export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Clie
 }
 
 export async function createUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
-  return sierraClient.getPatronRecordByEmail(request.body.email).then(sierraResponse => {
+  const sierraCheck = sierraClient.getPatronRecordByEmail(request.body.email);
+  const auth0Check = auth0Client.getProfileByEmail(request.body.email);
+  sierraCheck.then(sierraResponse => {
     if (sierraResponse.status === ResponseStatus.NotFound) {
-      auth0Client.getProfileByEmail(request.body.email).then(auth0Response => {
+      auth0Check.then(auth0Response => {
         if (auth0Response.status === ResponseStatus.NotFound) {
           return sierraClient.createPatronRecord(request.body.title, request.body.firstName, request.body.lastName, request.body.password).then(sierraResponse => {
             if (sierraResponse.status === ResponseStatus.Success) {

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -6,7 +6,7 @@ import { toMessage } from '../models/common';
 import { toUser } from '../models/user';
 
 export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
-  return sierraClient.getPatronRecordByRecordNumber(BigInt(request.params.user_id)).then(sierraResponse => {
+  return sierraClient.getPatronRecordByRecordNumber(Number(request.params.user_id)).then(sierraResponse => {
     if (sierraResponse.status === ResponseStatus.Success) {
       return auth0Client.getProfileByUserId(request.params.user_id).then(auth0Response => {
         if (auth0Response.status === ResponseStatus.Success) {

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -1,9 +1,9 @@
 import Auth0Client from '@weco/auth0-client';
-import { ResponseStatus } from '@weco/identity-common';
+import {ResponseStatus} from '@weco/identity-common';
 import SierraClient from '@weco/sierra-client';
-import { Request, Response } from 'express';
-import { toMessage } from '../models/common';
-import { toUser } from '../models/user';
+import {Request, Response} from 'express';
+import {toMessage} from '../models/common';
+import {toUser} from '../models/user';
 
 export async function getUser(sierraClient: SierraClient, auth0Client: Auth0Client, request: Request, response: Response): Promise<void> {
   return sierraClient.getPatronRecordByRecordNumber(Number(request.params.user_id)).then(sierraResponse => {
@@ -35,12 +35,16 @@ export async function createUser(sierraClient: SierraClient, auth0Client: Auth0C
               response.status(201).json(toUser(sierraResponse.result, auth0Response.result));
             } else if (sierraResponse.status === ResponseStatus.UserAlreadyExists) {
               response.status(409).json(toMessage(sierraResponse.message));
+            } else if (sierraResponse.status === ResponseStatus.MalformedRequest) {
+              response.status(400).json(toMessage(sierraResponse.message));
             } else {
               response.status(500).json(toMessage(sierraResponse.message));
             }
           });
         } else if (auth0Response.status === ResponseStatus.UserAlreadyExists) {
           response.status(409).json(toMessage(auth0Response.message));
+        } else if (auth0Response.status === ResponseStatus.MalformedRequest) {
+          response.status(400).json(toMessage(auth0Response.message));
         } else {
           response.status(500).json(toMessage(auth0Response.message));
         }

--- a/packages/apps/api/src/models/user.ts
+++ b/packages/apps/api/src/models/user.ts
@@ -19,7 +19,7 @@ export function toUser(patronRecord: PatronRecord, auth0User: Auth0Profile): Use
 }
 
 interface User {
-  patronId: bigint,
+  patronId: number,
   barcode: string,
   title: string,
   firstName: string,
@@ -30,7 +30,7 @@ interface User {
   creationDate: string,
   lastLogin: string,
   lastLoginIp: string,
-  totalLogins: bigint
+  totalLogins: number
 }
 
 

--- a/packages/apps/api/src/models/user.ts
+++ b/packages/apps/api/src/models/user.ts
@@ -8,7 +8,7 @@ export function toUser(patronRecord: PatronRecord, auth0User: Auth0Profile): Use
     title: patronRecord.title,
     firstName: patronRecord.firstName,
     lastName: patronRecord.lastName,
-    email: patronRecord.emailAddress,
+    email: patronRecord.email,
     emailValidated: auth0User.emailValidated,
     locked: auth0User.locked,
     creationDate: auth0User.creationDate,
@@ -19,7 +19,7 @@ export function toUser(patronRecord: PatronRecord, auth0User: Auth0Profile): Use
 }
 
 interface User {
-  patronId: number,
+  patronId: bigint,
   barcode: string,
   title: string,
   firstName: string,
@@ -30,12 +30,12 @@ interface User {
   creationDate: string,
   lastLogin: string,
   lastLoginIp: string,
-  totalLogins: number
+  totalLogins: bigint
 }
 
 
 export const DummyUserOne = {
-  patronId: '123456',
+  patronId: 123456,
   barcode: '654321',
   title: 'Mr',
   firstName: 'John',
@@ -50,7 +50,7 @@ export const DummyUserOne = {
 };
 
 export const DummyUserTwo = {
-  patronId: '654321',
+  patronId: 654321,
   barcode: '123456',
   title: 'Mrs',
   firstName: 'Jane',

--- a/packages/apps/api/src/models/user.ts
+++ b/packages/apps/api/src/models/user.ts
@@ -1,7 +1,7 @@
 import { Auth0Profile } from '@weco/auth0-client/lib/auth0';
 import { PatronRecord } from '@weco/sierra-client/lib/patron';
 
-export function toUser(patronRecord: PatronRecord, auth0User: Auth0Profile): User {
+export function toUser(patronRecord: PatronRecord, auth0Profile: Auth0Profile): User {
   return {
     patronId: patronRecord.recordNumber,
     barcode: patronRecord.barcode,
@@ -9,12 +9,12 @@ export function toUser(patronRecord: PatronRecord, auth0User: Auth0Profile): Use
     firstName: patronRecord.firstName,
     lastName: patronRecord.lastName,
     email: patronRecord.email,
-    emailValidated: auth0User.emailValidated,
-    locked: auth0User.locked,
-    creationDate: auth0User.creationDate,
-    lastLogin: auth0User.lastLogin,
-    lastLoginIp: auth0User.lastLoginIp,
-    totalLogins: auth0User.totalLogins
+    emailValidated: auth0Profile.emailValidated,
+    locked: auth0Profile.locked,
+    creationDate: auth0Profile.creationDate,
+    lastLogin: auth0Profile.lastLogin,
+    lastLoginIp: auth0Profile.lastLoginIp,
+    totalLogins: auth0Profile.totalLogins
   }
 }
 

--- a/packages/apps/auth0-actions/src/get_user.js
+++ b/packages/apps/auth0-actions/src/get_user.js
@@ -11,8 +11,12 @@ function getUser(email, callback) {
             user_id: 'p' + patronRecord.recordNumber,
             email: patronRecord.email
         });
-    }).catch(reason => {
-        callback(reason);
+    }).catch(error => {
+        if(error.response && error.response.status === 404) {
+            callback(null);
+        } else {
+            callback(error);
+        }
     });
 
     async function getPatronRecordByEmail(email) {

--- a/packages/apps/auth0-actions/src/get_user.js
+++ b/packages/apps/auth0-actions/src/get_user.js
@@ -9,7 +9,7 @@ function getUser(email, callback) {
     getPatronRecordByEmail(email).then(patronRecord => {
         callback(null, {
             user_id: 'p' + patronRecord.recordNumber,
-            email: patronRecord.emailAddress
+            email: patronRecord.email
         });
     }).catch(reason => {
         callback(reason);
@@ -53,7 +53,7 @@ function getUser(email, callback) {
         return Object.assign(patronName, {
             recordNumber: data.id,
             barcode: extractVarField(data.varFields, 'b'),
-            emailAddress: extractVarField(data.varFields, 'z')
+            email: extractVarField(data.varFields, 'z')
         }
         );
     }

--- a/packages/apps/auth0-actions/src/get_user.js
+++ b/packages/apps/auth0-actions/src/get_user.js
@@ -12,7 +12,7 @@ function getUser(email, callback) {
             email: patronRecord.email
         });
     }).catch(error => {
-        if(error.response && error.response.status === 404) {
+        if (error.response && error.response.status === 404) {
             callback(null);
         } else {
             callback(error);

--- a/packages/apps/auth0-actions/src/login.js
+++ b/packages/apps/auth0-actions/src/login.js
@@ -10,7 +10,7 @@ function login(email, password, callback) {
         validateCredentials(patronRecord.barcode, password).then(() => {
             callback(null, {
                 user_id: 'p' + patronRecord.recordNumber,
-                email: patronRecord.emailAddress
+                email: patronRecord.email
             });
         }).catch(reason => {
             callback(reason)
@@ -85,7 +85,7 @@ function login(email, password, callback) {
         return Object.assign(patronName, {
             recordNumber: data.id,
             barcode: extractVarField(data.varFields, 'b'),
-            emailAddress: extractVarField(data.varFields, 'z')
+            email: extractVarField(data.varFields, 'z')
         }
         );
     }

--- a/packages/apps/auth0-actions/src/login.js
+++ b/packages/apps/auth0-actions/src/login.js
@@ -12,11 +12,11 @@ function login(email, password, callback) {
                 user_id: 'p' + patronRecord.recordNumber,
                 email: patronRecord.email
             });
-        }).catch(reason => {
-            callback(reason)
+        }).catch(error => {
+            callback(error)
         });
-    }).catch(reason => {
-        callback(reason);
+    }).catch(error => {
+        callback(error);
     });
 
     async function validateCredentials(barcode, pin) {

--- a/packages/apps/auth0-actions/src/login.js
+++ b/packages/apps/auth0-actions/src/login.js
@@ -80,23 +80,47 @@ function login(email, password, callback) {
     }
 
     function toPatronRecord(data) {
-        const nameVarField = extractVarField(data.varFields, 'n');
-        const patronName = getPatronName(nameVarField);
+        const patronName = getPatronName(data.varFields);
         return Object.assign(patronName, {
             recordNumber: data.id,
-            barcode: extractVarField(data.varFields, 'b'),
-            email: extractVarField(data.varFields, 'z')
-        }
-        );
+            barcode: getVarFieldContent(data.varFields, 'b'),
+            email: getVarFieldContent(data.varFields, 'z')
+        });
     }
 
-    function extractVarField(varFields, fieldTag) {
+    function getVarFieldContent(varFields, fieldTag) {
         const found = varFields.find(varField => varField.fieldTag === fieldTag);
-        return found ? found.content : '';
+        return found ? found.content || '' : '';
     }
 
-    function getPatronName(varField) {
-        if (!varField.trim()) {
+    function getPatronName(varFields) {
+        const found = varFields.find(varField => varField.fieldTag === 'n');
+        if (found && found.content) {
+            return getPatronNameNonMarc(found.content);
+        } else if (found && found.subfields) {
+            return getPatronNameMarc(found.subfields);
+        } else {
+            return {
+                title: '',
+                firstName: '',
+                lastName: ''
+            }
+        }
+    }
+
+    function getPatronNameMarc(subFields) {
+        const title = subFields.find(subField => subField.tag === 'c')
+        const firstName = subFields.find(subField => subField.tag === 'b')
+        const lastName = subFields.find(subField => subField.tag === 'a')
+        return {
+            title: title ? title.content.trim() : '',
+            firstName: firstName ? firstName.content.trim() : '',
+            lastName: lastName ? lastName.content.trim() : ''
+        }
+    }
+
+    function getPatronNameNonMarc(content) {
+        if (!content.trim()) {
             return {
                 title: '',
                 firstName: '',
@@ -104,23 +128,23 @@ function login(email, password, callback) {
             };
         }
 
-        varField = varField.replace('100', '').replace('a|', '').replace('_', '');
+        content = content.replace('100', '').replace('a|', '').replace('_', '');
 
         let lastName = '';
-        if (varField.includes(',')) {
-            lastName = varField.substring(0, varField.indexOf(','));
+        if (content.includes(',')) {
+            lastName = content.substring(0, content.indexOf(','));
         }
 
         let title = '';
-        if (varField.includes('|c')) {
-            title = varField.substring(varField.indexOf('|c') + 2, varField.indexOf('|b'));
+        if (content.includes('|c')) {
+            title = content.substring(content.indexOf('|c') + 2, content.indexOf('|b'));
         }
 
         let firstName = '';
-        if (varField.includes('|b')) {
-            firstName = varField.substring(varField.indexOf('|b') + 2, varField.length);
+        if (content.includes('|b')) {
+            firstName = content.substring(content.indexOf('|b') + 2, content.length);
         } else {
-            firstName = varField.substring(varField.indexOf(',') + 1, varField.length);
+            firstName = content.substring(content.indexOf(',') + 1, content.length);
         }
 
         return {

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from 'axios';
 
 const USER_ID_PREFIX: string = 'auth0|p';
 
-export function toAuth0UserId(userId: string): string {
+export function toAuth0UserId(userId: number): string {
   return USER_ID_PREFIX + userId;
 }
 

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -1,31 +1,32 @@
-import { AxiosResponse } from 'axios';
-
-export function toUserInfo(response: AxiosResponse): Auth0UserInfo {
-  const sub = response.data.sub;
+export function toAuth0UserInfo(userInfo: any): Auth0UserInfo {
+  const sub = userInfo.sub;
   return {
+    // As far as the application is concerned, Auth0 ID's are identical to Sierra ID's. So remove the mandatory Auth0 prefix.
     userId: sub.slice(sub.indexOf('auth0|p') + 'auth0|p'.length),
-    email: response.data.email
+    email: userInfo.email
   }
 }
 
-export function toUserProfile(data: any): Auth0Profile {
+export function toAuth0Profile(auth0User: any): Auth0Profile {
   return {
-    userId: data.user_id,
-    email: data.email,
-    emailValidated: data.email_verified,
-    locked: data.blocked ? data.blocked : false,
-    creationDate: data.created_at,
-    lastLogin: data.last_login,
-    lastLoginIp: data.last_ip,
-    totalLogins: data.logins_count
+    userId: auth0User.user_id,
+    email: auth0User.email,
+    emailValidated: auth0User.email_verified,
+    locked: auth0User.blocked ? auth0User.blocked : false, // Auth0 quirk - this attribute doesn't appear on Auth0 responses until it's been toggled off and on at least once.
+    creationDate: auth0User.created_at,
+    lastLogin: auth0User.last_login,
+    lastLoginIp: auth0User.last_ip,
+    totalLogins: auth0User.logins_count
   }
 }
 
+// A simple representation of the Auth0 user, using only the attributes we provide to Auth0 to create it.
 export interface Auth0UserInfo {
   userId: number;
   email: string;
 }
 
+// An enhanced representation of the Auth0 user, it includes the various pieces of metadata which Auth0 provides about the user.
 export interface Auth0Profile extends Auth0UserInfo {
   emailValidated: boolean,
   locked: boolean,

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -1,15 +1,9 @@
 import { AxiosResponse } from 'axios';
 
-const USER_ID_PREFIX: string = 'auth0|p';
-
-export function toAuth0UserId(userId: number): string {
-  return USER_ID_PREFIX + userId;
-}
-
 export function toUserInfo(response: AxiosResponse): Auth0UserInfo {
   const sub = response.data.sub;
   return {
-    userId: sub.slice(sub.indexOf(USER_ID_PREFIX) + USER_ID_PREFIX.length),
+    userId: sub.slice(sub.indexOf('auth0|p') + 'auth0|p'.length),
     email: response.data.email
   }
 }

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -28,7 +28,7 @@ export function toUserProfile(response: AxiosResponse): Auth0Profile {
 }
 
 export interface Auth0UserInfo {
-  userId: bigint;
+  userId: number;
   email: string;
 }
 
@@ -38,5 +38,5 @@ export interface Auth0Profile extends Auth0UserInfo {
   creationDate: string,
   lastLogin: string,
   lastLoginIp: string,
-  totalLogins: bigint
+  totalLogins: number
 }

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -28,7 +28,7 @@ export function toUserProfile(response: AxiosResponse): Auth0Profile {
 }
 
 export interface Auth0UserInfo {
-  userId: number;
+  userId: bigint;
   email: string;
 }
 
@@ -38,5 +38,5 @@ export interface Auth0Profile extends Auth0UserInfo {
   creationDate: string,
   lastLogin: string,
   lastLoginIp: string,
-  totalLogins: number
+  totalLogins: bigint
 }

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -14,16 +14,16 @@ export function toUserInfo(response: AxiosResponse): Auth0UserInfo {
   }
 }
 
-export function toUserProfile(response: AxiosResponse): Auth0Profile {
+export function toUserProfile(data: any): Auth0Profile {
   return {
-    userId: response.data.user_id,
-    email: response.data.email,
-    emailValidated: response.data.email_verified,
-    locked: response.data.blocked ? response.data.blocked : false,
-    creationDate: response.data.created_at,
-    lastLogin: response.data.last_login,
-    lastLoginIp: response.data.last_ip,
-    totalLogins: response.data.logins_count
+    userId: data.user_id,
+    email: data.email,
+    emailValidated: data.email_verified,
+    locked: data.blocked ? data.blocked : false,
+    creationDate: data.created_at,
+    lastLogin: data.last_login,
+    lastLoginIp: data.last_ip,
+    totalLogins: data.logins_count
   }
 }
 

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -34,7 +34,7 @@ export default class Auth0Client {
 
   async getProfileByUserId(userId: string): Promise<APIResponse<Auth0Profile>> {
     return this.getMachineToMachineInstance().then(instance => {
-      return instance.get('/users/' + toAuth0UserId(userId), {
+      return instance.get('/users/' + toAuth0UserId(Number(userId)), {
         validateStatus: status => status === 200
       }).then(response =>
         successResponse(toUserProfile(response))

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -25,7 +25,7 @@ export default class Auth0Client {
       if (error.response) {
         switch (error.response.status) {
           case 401:
-            return errorResponse('Auth0 access token [' + accessToken + '] not valid', ResponseStatus.InvalidCredentials);
+            return errorResponse(error, 'Auth0 access token [' + accessToken + '] not valid', ResponseStatus.InvalidCredentials);
         }
       }
       return unhandledError(error);
@@ -42,7 +42,7 @@ export default class Auth0Client {
         if (error.response) {
           switch (error.response.status) {
             case 404:
-              return errorResponse('Auth0 user with ID [' + userId + '] not found', ResponseStatus.NotFound);
+              return errorResponse(error,'Auth0 user with ID [' + userId + '] not found', ResponseStatus.NotFound);
           }
         }
         return unhandledError(error);
@@ -63,7 +63,7 @@ export default class Auth0Client {
         if (error.response) {
           switch (error.response.status) {
             case 404:
-              return errorResponse('Auth0 user with email [' + email + '] not found', ResponseStatus.NotFound);
+              return errorResponse(error, 'Auth0 user with email [' + email + '] not found', ResponseStatus.NotFound);
           }
         }
         return unhandledError(error);
@@ -86,8 +86,10 @@ export default class Auth0Client {
       ).catch(error => {
         if (error.response) {
           switch (error.response.status) {
+            case 400:
+              return errorResponse(error, 'Malformed or invalid Auth0 user creation request', ResponseStatus.MalformedRequest);
             case 409:
-              return errorResponse('AUth0 user with email [' + email + '] already exists', ResponseStatus.UserAlreadyExists)
+              return errorResponse(error, 'AUth0 user with email [' + email + '] already exists', ResponseStatus.UserAlreadyExists);
           }
         }
         return unhandledError(error);

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -1,6 +1,7 @@
 import { APIResponse, errorResponse, ResponseStatus, successResponse, unhandledError } from '@weco/identity-common';
 import axios, { AxiosInstance } from 'axios';
 import { Auth0Profile, Auth0UserInfo, toAuth0UserId, toUserInfo, toUserProfile } from './auth0';
+import {toPatronRecord} from "@weco/sierra-client/lib/patron";
 
 export default class Auth0Client {
 
@@ -69,9 +70,10 @@ export default class Auth0Client {
     });
   }
 
-  async createAccount(email: string, password: string): Promise<APIResponse<Auth0Profile>> {
+  async createAccount(userId: number, email: string, password: string): Promise<APIResponse<Auth0Profile>> {
     return this.getMachineToMachineInstance().then(instance => {
       return instance.post('/users', {
+        user_id: toAuth0UserId(userId),
         email: email,
         password: password,
         email_verified: false,

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -72,7 +72,7 @@ export default class Auth0Client {
   async createUser(userId: number, email: string, password: string): Promise<APIResponse<Auth0Profile>> {
     return this.getMachineToMachineInstance().then(instance => {
       return instance.post('/users', {
-        user_id: userId,
+        user_id: userId.toString(),
         email: email,
         password: password,
         email_verified: false,

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -77,7 +77,6 @@ export default class Auth0Client {
         email: email,
         password: password,
         email_verified: false,
-        verify_email: true,
         connection: 'Sierra-Connection'
       }, {
         validateStatus: status => status === 201

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -1,7 +1,6 @@
 import { APIResponse, errorResponse, ResponseStatus, successResponse, unhandledError } from '@weco/identity-common';
 import axios, { AxiosInstance } from 'axios';
 import { Auth0Profile, Auth0UserInfo, toAuth0UserId, toUserInfo, toUserProfile } from './auth0';
-import {toPatronRecord} from "@weco/sierra-client/lib/patron";
 
 export default class Auth0Client {
 

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -72,7 +72,7 @@ export default class Auth0Client {
   async createUser(userId: number, email: string, password: string): Promise<APIResponse<Auth0Profile>> {
     return this.getMachineToMachineInstance().then(instance => {
       return instance.post('/users', {
-        user_id: userId.toString(),
+        user_id: 'p' + userId,
         email: email,
         password: password,
         email_verified: false,

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -1,6 +1,6 @@
 import { APIResponse, errorResponse, ResponseStatus, successResponse, unhandledError } from '@weco/identity-common';
 import axios, { AxiosInstance } from 'axios';
-import { Auth0Profile, Auth0UserInfo, toAuth0UserId, toUserInfo, toUserProfile } from './auth0';
+import { Auth0Profile, Auth0UserInfo, toUserInfo, toUserProfile } from './auth0';
 
 export default class Auth0Client {
 
@@ -34,7 +34,7 @@ export default class Auth0Client {
 
   async getProfileByUserId(userId: string): Promise<APIResponse<Auth0Profile>> {
     return this.getMachineToMachineInstance().then(instance => {
-      return instance.get('/users/' + toAuth0UserId(Number(userId)), {
+      return instance.get('/users/auth0|p' + userId, {
         validateStatus: status => status === 200
       }).then(response =>
         successResponse(toUserProfile(response.data))

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -78,7 +78,7 @@ export default class Auth0Client {
         verify_email: true,
         connection: 'Sierra-Connection'
       }, {
-        validateStatus: status => status === 201
+        validateStatus: status => status === 200
       }).then(response =>
         successResponse(toUserProfile(response.data))
       ).catch(error => {

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -78,7 +78,7 @@ export default class Auth0Client {
         verify_email: true,
         connection: 'Sierra-Connection'
       }, {
-        validateStatus: status => status === 200
+        validateStatus: status => status === 201
       }).then(response =>
         successResponse(toUserProfile(response.data))
       ).catch(error => {

--- a/packages/shared/auth0-client/src/index.ts
+++ b/packages/shared/auth0-client/src/index.ts
@@ -69,10 +69,10 @@ export default class Auth0Client {
     });
   }
 
-  async createAccount(userId: number, email: string, password: string): Promise<APIResponse<Auth0Profile>> {
+  async createUser(userId: number, email: string, password: string): Promise<APIResponse<Auth0Profile>> {
     return this.getMachineToMachineInstance().then(instance => {
       return instance.post('/users', {
-        user_id: toAuth0UserId(userId),
+        user_id: userId,
         email: email,
         password: password,
         email_verified: false,

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -7,16 +7,16 @@ export function successResponse<T>(result: T): SuccessResponse<T> {
   }
 }
 
-export function errorResponse(message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest): ErrorResponse {
+export function errorResponse(error: AxiosError, message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest): ErrorResponse {
   return {
-    message: message,
+    message: message + '(cause: [' + JSON.stringify(error) + '])',
     status: status
   }
 }
 
 export function unhandledError(error: AxiosError): ErrorResponse {
   return {
-    message: 'Unexpected API response: [' + error.message + ']',
+    message: 'Unhandled API response [' + JSON.stringify(error)+ ']',
     status: ResponseStatus.UnknownError
   }
 }

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -7,8 +7,8 @@ export function successResponse<T>(result: T): SuccessResponse<T> {
   }
 }
 
-export function errorResponse(error: AxiosError, message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest | ResponseStatus.UnknownError): ErrorResponse {
-  const cause = error.response ? error.response.data : error.message;
+export function errorResponse(message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest | ResponseStatus.UnknownError, error?: AxiosError): ErrorResponse {
+  const cause = error ? (error.response ? error.response.data : error.message) : '';
   return {
     message: message + ' (cause: [' + cause + '])',
     status: status
@@ -16,7 +16,7 @@ export function errorResponse(error: AxiosError, message: string, status: Respon
 }
 
 export function unhandledError(error: AxiosError): ErrorResponse {
-  return errorResponse(error, 'Unhandled API response [' + error.message + ']', ResponseStatus.UnknownError);
+  return errorResponse('Unhandled API response [' + error.message + ']', ResponseStatus.UnknownError, error);
 }
 
 export type SuccessResponse<T> = {

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -7,7 +7,7 @@ export function successResponse<T>(result: T): SuccessResponse<T> {
   }
 }
 
-export function errorResponse(message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists): ErrorResponse {
+export function errorResponse(message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest): ErrorResponse {
   return {
     message: message,
     status: status
@@ -28,7 +28,7 @@ export type SuccessResponse<T> = {
 
 export type ErrorResponse = {
   message: string,
-  status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.UnknownError
+  status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest | ResponseStatus.UnknownError
 }
 
 export enum ResponseStatus {
@@ -36,6 +36,7 @@ export enum ResponseStatus {
   NotFound,
   InvalidCredentials,
   UserAlreadyExists,
+  MalformedRequest,
   UnknownError
 }
 

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -7,8 +7,15 @@ export function successResponse<T>(result: T): SuccessResponse<T> {
   }
 }
 
-export function errorResponse(message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest | ResponseStatus.UnknownError, error?: AxiosError): ErrorResponse {
-  const cause = error ? (error.response ? JSON.stringify(error.response.data) : error.message) : '';
+export function errorResponse(
+  message: string,
+  status: ResponseStatus.NotFound
+    | ResponseStatus.InvalidCredentials
+    | ResponseStatus.UserAlreadyExists
+    | ResponseStatus.MalformedRequest
+    | ResponseStatus.UnknownError,
+  error?: AxiosError): ErrorResponse {
+  const cause = error ? (error.response ? JSON.stringify(error.response.data) : error.message) : 'unknown';
   return {
     message: message + ' (cause: [' + cause + '])',
     status: status
@@ -26,7 +33,11 @@ export type SuccessResponse<T> = {
 
 export type ErrorResponse = {
   message: string,
-  status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest | ResponseStatus.UnknownError
+  status: ResponseStatus.NotFound
+  | ResponseStatus.InvalidCredentials
+  | ResponseStatus.UserAlreadyExists
+  | ResponseStatus.MalformedRequest
+  | ResponseStatus.UnknownError
 }
 
 export enum ResponseStatus {

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -7,18 +7,16 @@ export function successResponse<T>(result: T): SuccessResponse<T> {
   }
 }
 
-export function errorResponse(error: AxiosError, message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest): ErrorResponse {
+export function errorResponse(error: AxiosError, message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest | ResponseStatus.UnknownError): ErrorResponse {
+  const cause = error.response ? error.response.data : error.message;
   return {
-    message: message + '(cause: [' + JSON.stringify(error) + '])',
+    message: message + ' (cause: [' + cause + '])',
     status: status
   }
 }
 
 export function unhandledError(error: AxiosError): ErrorResponse {
-  return {
-    message: 'Unhandled API response [' + JSON.stringify(error)+ ']',
-    status: ResponseStatus.UnknownError
-  }
+  return errorResponse(error, 'Unhandled API response [' + error.message + ']', ResponseStatus.UnknownError);
 }
 
 export type SuccessResponse<T> = {

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -8,7 +8,7 @@ export function successResponse<T>(result: T): SuccessResponse<T> {
 }
 
 export function errorResponse(message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.MalformedRequest | ResponseStatus.UnknownError, error?: AxiosError): ErrorResponse {
-  const cause = error ? (error.response ? error.response.data : error.message) : '';
+  const cause = error ? (error.response ? JSON.stringify(error.response.data) : error.message) : '';
   return {
     message: message + ' (cause: [' + cause + '])',
     status: status

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -7,7 +7,7 @@ export function successResponse<T>(result: T): SuccessResponse<T> {
   }
 }
 
-export function errorResponse(message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials): ErrorResponse {
+export function errorResponse(message: string, status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists): ErrorResponse {
   return {
     message: message,
     status: status
@@ -28,13 +28,14 @@ export type SuccessResponse<T> = {
 
 export type ErrorResponse = {
   message: string,
-  status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UnknownError
+  status: ResponseStatus.NotFound | ResponseStatus.InvalidCredentials | ResponseStatus.UserAlreadyExists | ResponseStatus.UnknownError
 }
 
 export enum ResponseStatus {
   Success,
   NotFound,
   InvalidCredentials,
+  UserAlreadyExists,
   UnknownError
 }
 

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -1,5 +1,9 @@
 import { AxiosError } from 'axios';
 
+export function isNonBlank(str: string): boolean {
+  return !!(str && /\S/.test(str));
+}
+
 export function successResponse<T>(result: T): SuccessResponse<T> {
   return {
     result: result,

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -1,7 +1,7 @@
-import {APIResponse, errorResponse, ResponseStatus, successResponse, unhandledError} from '@weco/identity-common';
-import type {AxiosInstance} from 'axios';
+import { APIResponse, errorResponse, ResponseStatus, successResponse, unhandledError } from '@weco/identity-common';
+import type { AxiosInstance } from 'axios';
 import axios from 'axios';
-import {extractRecordNumberFromCreate, PatronRecord, toCreatePatron, toPatronRecord} from './patron';
+import { extractRecordNumberFromCreate, PatronRecord, toCreatePatron, toPatronRecord } from './patron';
 
 export default class SierraClient {
 
@@ -28,7 +28,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 400:
-              return errorResponse('Invalid Patron credentials for barcode [' + barcode + ']', ResponseStatus.InvalidCredentials);
+              return errorResponse(error, 'Invalid Patron credentials for barcode [' + barcode + ']', ResponseStatus.InvalidCredentials);
           }
         }
         return unhandledError(error);
@@ -49,7 +49,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 404:
-              return errorResponse('Patron record with record number [' + recordNumber + '] not found', ResponseStatus.NotFound);
+              return errorResponse(error, 'Patron record with record number [' + recordNumber + '] not found', ResponseStatus.NotFound);
           }
         }
         return unhandledError(error);
@@ -72,7 +72,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 404:
-              return errorResponse('Patron record with barcode [' + barcode + '] not found', ResponseStatus.NotFound);
+              return errorResponse(error, 'Patron record with barcode [' + barcode + '] not found', ResponseStatus.NotFound);
           }
         }
         return unhandledError(error);
@@ -95,7 +95,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 404:
-              return errorResponse('Patron record with email address [' + email + '] not found', ResponseStatus.NotFound);
+              return errorResponse(error, 'Patron record with email address [' + email + '] not found', ResponseStatus.NotFound);
           }
         }
         return unhandledError(error);
@@ -117,7 +117,7 @@ export default class SierraClient {
           if (error.response) {
             switch (error.response.status) {
               case 400:
-                return errorResponse('Malformed or invalid Patron barcode update request', ResponseStatus.MalformedRequest);
+                return errorResponse(error, 'Malformed or invalid Patron barcode update request', ResponseStatus.MalformedRequest);
             }
           }
           return unhandledError(error);
@@ -126,7 +126,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 400:
-              return errorResponse('Malformed or invalid Patron creation request', ResponseStatus.MalformedRequest);
+              return errorResponse(error, 'Malformed or invalid Patron record creation request', ResponseStatus.MalformedRequest);
           }
         }
         return unhandledError(error);

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -108,11 +108,13 @@ export default class SierraClient {
       return instance.post('/v6/patrons', toCreatePatron(title, firstName, lastName, email, pin), {
         validateStatus: status => status === 201
       }).then(response => {
-        const recordNumber = extractRecordNumberFromCreate(response.data.link);
+        const recordNumber = extractRecordNumberFromCreate(response.data.link).toString();
         return instance.put('/v6/patrons/' + recordNumber, {
-          barcodes: [recordNumber.toString()]
+          barcodes: [recordNumber]
+        },{
+          validateStatus: status => status === 200
         }).then(() =>
-          this.getPatronRecordByBarcode(recordNumber.toString())
+          this.getPatronRecordByBarcode(recordNumber)
         ).catch(error => {
           if (error.response) {
             switch (error.response.status) {

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -113,12 +113,24 @@ export default class SierraClient {
           barcodes: [recordNumber.toString()]
         }).then(() =>
           this.getPatronRecordByBarcode(recordNumber.toString())
-        ).catch(error =>
-          unhandledError(error)
-        );
-      }).catch(error =>
-        unhandledError(error)
-      );
+        ).catch(error => {
+          if (error.response) {
+            switch (error.response.status) {
+              case 400:
+                return errorResponse('Malformed or invalid Patron barcode update request', ResponseStatus.MalformedRequest);
+            }
+          }
+          return unhandledError(error);
+        });
+      }).catch(error => {
+        if (error.response) {
+          switch (error.response.status) {
+            case 400:
+              return errorResponse('Malformed or invalid Patron creation request', ResponseStatus.MalformedRequest);
+          }
+        }
+        return unhandledError(error);
+      });
     });
   }
 

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -106,15 +106,15 @@ export default class SierraClient {
   async createPatronRecord(title: string, firstName: string, lastName: string, email: string, pin: string): Promise<APIResponse<PatronRecord>> {
     return this.getInstance().then(instance => {
       return instance.post('/v6/patrons', toCreatePatron(title, firstName, lastName, email, pin), {
-        validateStatus: status => status === 201
+        validateStatus: status => status === 200
       }).then(response => {
-        const recordNumber = extractRecordNumberFromCreate(response.data.link).toString();
+        const recordNumber = extractRecordNumberFromCreate(response.data.link);
         return instance.put('/v6/patrons/' + recordNumber, {
-          barcodes: [recordNumber]
+          barcodes: [recordNumber.toString()]
         },{
           validateStatus: status => status === 200
         }).then(() =>
-          this.getPatronRecordByBarcode(recordNumber)
+          this.getPatronRecordByRecordNumber(recordNumber)
         ).catch(error => {
           if (error.response) {
             switch (error.response.status) {

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -121,7 +121,7 @@ export default class SierraClient {
     });
   }
 
-  async updatePatronRecord(recordNumber: number, email: string): Promise<APIResponse<PatronRecord>> {
+  async addPostCreationFields(recordNumber: number, email: string): Promise<APIResponse<PatronRecord>> {
     return this.getInstance().then(instance => {
       return instance.put('/v6/patrons/' + recordNumber, {
         emails: [email],

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -112,7 +112,7 @@ export default class SierraClient {
         return instance.put('/v6/patrons/' + recordNumber, {
           barcodes: [recordNumber.toString()]
         },{
-          validateStatus: status => status === 200
+          validateStatus: status => status === 204
         }).then(() =>
           this.getPatronRecordByRecordNumber(recordNumber)
         ).catch(error => {

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -36,7 +36,7 @@ export default class SierraClient {
     });
   }
 
-  async getPatronRecordByRecordNumber(recordNumber: bigint): Promise<APIResponse<PatronRecord>> {
+  async getPatronRecordByRecordNumber(recordNumber: number): Promise<APIResponse<PatronRecord>> {
     return this.getInstance().then(instance => {
       return instance.get('/v6/patrons/' + recordNumber, {
         params: {

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -1,5 +1,5 @@
 import { APIResponse, errorResponse, ResponseStatus, successResponse, unhandledError } from '@weco/identity-common';
-import type { AxiosInstance } from 'axios';
+import type {AxiosInstance} from 'axios';
 import axios from 'axios';
 import { extractRecordNumberFromCreate, PatronRecord, toCreatePatron, toPatronRecord } from './patron';
 
@@ -28,7 +28,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 400:
-              return errorResponse(error, 'Invalid Patron credentials for barcode [' + barcode + ']', ResponseStatus.InvalidCredentials);
+              return errorResponse('Invalid Patron credentials for barcode [' + barcode + ']', ResponseStatus.InvalidCredentials, error);
           }
         }
         return unhandledError(error);
@@ -49,7 +49,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 404:
-              return errorResponse(error, 'Patron record with record number [' + recordNumber + '] not found', ResponseStatus.NotFound);
+              return errorResponse('Patron record with record number [' + recordNumber + '] not found', ResponseStatus.NotFound, error);
           }
         }
         return unhandledError(error);
@@ -72,7 +72,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 404:
-              return errorResponse(error, 'Patron record with barcode [' + barcode + '] not found', ResponseStatus.NotFound);
+              return errorResponse('Patron record with barcode [' + barcode + '] not found', ResponseStatus.NotFound, error);
           }
         }
         return unhandledError(error);
@@ -95,7 +95,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 404:
-              return errorResponse(error, 'Patron record with email address [' + email + '] not found', ResponseStatus.NotFound);
+              return errorResponse('Patron record with email address [' + email + '] not found', ResponseStatus.NotFound, error);
           }
         }
         return unhandledError(error);
@@ -117,7 +117,7 @@ export default class SierraClient {
           if (error.response) {
             switch (error.response.status) {
               case 400:
-                return errorResponse(error, 'Malformed or invalid Patron barcode update request', ResponseStatus.MalformedRequest);
+                return errorResponse('Malformed or invalid Patron barcode update request', ResponseStatus.MalformedRequest, error);
             }
           }
           return unhandledError(error);
@@ -126,7 +126,7 @@ export default class SierraClient {
         if (error.response) {
           switch (error.response.status) {
             case 400:
-              return errorResponse(error, 'Malformed or invalid Patron record creation request', ResponseStatus.MalformedRequest);
+              return errorResponse('Malformed or invalid Patron record creation request', ResponseStatus.MalformedRequest, error);
           }
         }
         return unhandledError(error);

--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -85,7 +85,27 @@ export function toCreatePatron(title: string, firstName: string, lastName: strin
         label: "USER CAT.",
         value: "13"
       },
-    }
+    },
+    varFields: [
+      {
+        fieldTag: "n",
+        marcTag: "100",
+        subfields: [
+          {
+            tag: "a",
+            content: lastName
+          },
+          {
+            tag: "c",
+            content: title
+          },
+          {
+            tag: "b",
+            content: firstName
+          }
+        ]
+      }
+    ]
   }
 }
 
@@ -117,7 +137,15 @@ export interface PatronCreate {
       label: string,
       value: string
     }
-  }
+  },
+  varFields: {
+    fieldTag: string,
+    marcTag: string,
+    subfields: {
+      tag: string,
+      content: string
+    }[]
+  }[]
 }
 
 interface VarField {

--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -80,7 +80,7 @@ export function toCreatePatron(title: string, firstName: string, lastName: strin
     pin: pin,
     pMessage: 's',
     homeLibraryCode: 'sreg',
-    patronType: BigInt(29),
+    patronType: 29,
     fixedFields: {
       46: {
         label: "USER CAT.",
@@ -90,16 +90,16 @@ export function toCreatePatron(title: string, firstName: string, lastName: strin
   }
 }
 
-export function extractRecordNumberFromCreate(link: string): bigint {
+export function extractRecordNumberFromCreate(link: string): number {
   const match = link.match(/^https:\/\/.+?\/v6\/patrons\/(\d+)$/);
   if (!match || match.length < 2) {
     throw new Error('Patron creation link [' + link + '] not in expected format');
   }
-  return BigInt(match[1]);
+  return Number(match[1]);
 }
 
 export interface PatronRecord {
-  recordNumber: bigint;
+  recordNumber: number;
   barcode: string;
   title: string;
   firstName: string;
@@ -113,7 +113,7 @@ export interface PatronCreate {
   pin: string,
   pMessage: string,
   homeLibraryCode: string,
-  patronType: bigint,
+  patronType: number,
   fixedFields: {
     46: {
       label: string,

--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -73,9 +73,8 @@ function getPatronNameNonMarc(content: string): { title: string, firstName: stri
   };
 }
 
-export function toCreatePatron(title: string, firstName: string, lastName: string, email: string, pin: string): PatronCreate {
+export function toCreatePatron(title: string, firstName: string, lastName: string, pin: string): PatronCreate {
   return {
-    emails: [email],
     names: [lastName + ',' + ' ' + title + ' ' + firstName],
     pin: pin,
     pMessage: 's',
@@ -108,7 +107,6 @@ export interface PatronRecord {
 }
 
 export interface PatronCreate {
-  emails: string[],
   names: string[],
   pin: string,
   pMessage: string,

--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -75,7 +75,6 @@ function getPatronNameNonMarc(content: string): { title: string, firstName: stri
 
 export function toCreatePatron(title: string, firstName: string, lastName: string, pin: string): PatronCreate {
   return {
-    names: [lastName + ',' + ' ' + title + ' ' + firstName],
     pin: pin,
     pMessage: 's',
     homeLibraryCode: 'sreg',
@@ -127,7 +126,6 @@ export interface PatronRecord {
 }
 
 export interface PatronCreate {
-  names: string[],
   pin: string,
   pMessage: string,
   homeLibraryCode: string,


### PR DESCRIPTION
Implements the `[POST] /users` API operation. This involves creation of a Patron record in Sierra and a corresponding Auth0 user, the two of which are linked together via their corresponding identifiers.