### PR TITLE
Implement maximum password length management

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -5,7 +5,8 @@ resource "auth0_client" "dummy_test" {
   custom_login_page_on = true
 
   callbacks = [
-    "https://${local.auth0_hostname}/login/callback"
+    "https://${local.auth0_hostname}/login/callback",
+    "https://oauth.pstmn.io/v1/callback"
   ]
 
   lifecycle {

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -86,7 +86,8 @@ resource "auth0_client_grant" "buildkite" {
     "read:prompts",
     "update:prompts",
     "read:branding",
-    "update:branding"
+    "update:branding",
+    "read:actions"
   ]
 }
 

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -1,6 +1,6 @@
 import Auth0Client from '@weco/auth0-client';
 import { Auth0Profile } from "@weco/auth0-client/lib/auth0";
-import { APIResponse, isNonBlank, ResponseStatus } from '@weco/identity-common';
+import { APIResponse, isNonBlank, ResponseStatus, truncate } from '@weco/identity-common';
 import SierraClient from '@weco/sierra-client';
 import { PatronRecord } from "@weco/sierra-client/lib/patron";
 import { Request, Response } from 'express';
@@ -51,11 +51,15 @@ export async function createUser(sierraClient: SierraClient, auth0Client: Auth0C
     if (auth0Get.status === ResponseStatus.NotFound) {
 
       // At this point the given email address isn't in use in Patron or Auth0, so create a new "barebones" Patron
-      // record for the user - this is a record which doesn't have an email address or barcode associated with it.
-      const sierraCreate: APIResponse<number> = await sierraClient.createPatronRecord(firstName, lastName, password);
+      // record for the user - this is a record which doesn't have an email address or barcode associated with it. When
+      // we set the Sierra password, we truncate it to 31 characters if necessary - Sierra will return an error if the
+      // password is greater than 31 characters.
+      const sierraCreate: APIResponse<number> = await sierraClient.createPatronRecord(firstName, lastName, truncate(password, 31));
       if (sierraCreate.status === ResponseStatus.Success) {
 
         // Create the corresponding Auth0 user, using the Patron record number from the previous step as the user ID.
+        // Note that there's no limitation on password length here - Auth0 will accept any password length, but they use
+        // bcrypt under the hood and thus only the first 72 characters are actually used to store / compare passwords.
         const auth0Create: APIResponse<Auth0Profile> = await auth0Client.createUser(sierraCreate.result, email, password);
         if (auth0Create.status === ResponseStatus.Success) {
 
@@ -111,7 +115,7 @@ export async function createUser(sierraClient: SierraClient, auth0Client: Auth0C
       } else if (sierraCreate.status === ResponseStatus.PasswordTooWeak) {
         response.status(422).json(toMessage(sierraCreate.message));
 
-        // An unhandled error occurred trying to create the Patorn record.
+        // An unhandled error occurred trying to create the Patron record.
       } else {
         response.status(500).json(toMessage(sierraCreate.message));
       }

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -54,7 +54,7 @@ export async function createUser(sierraClient: SierraClient, auth0Client: Auth0C
       // record for the user - this is a record which doesn't have an email address or barcode associated with it. When
       // we set the Sierra password, we truncate it to 31 characters if necessary - Sierra will return an error if the
       // password is greater than 31 characters.
-      const sierraCreate: APIResponse<number> = await sierraClient.createPatronRecord(firstName, lastName, truncate(password, 31));
+      const sierraCreate: APIResponse<number> = await sierraClient.createPatronRecord(firstName, lastName, truncate(password, 30));
       if (sierraCreate.status === ResponseStatus.Success) {
 
         // Create the corresponding Auth0 user, using the Patron record number from the previous step as the user ID.

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -8,7 +8,7 @@ export function truncate(str: string, length: number): string {
   if (str.length <= length) {
     return str;
   }
-  return str.substr(0, length - 1);
+  return str.substr(0, length);
 }
 
 export function successResponse<T>(result: T): SuccessResponse<T> {

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -4,6 +4,13 @@ export function isNonBlank(str: string): boolean {
   return !!(str && /\S/.test(str));
 }
 
+export function truncate(str: string, length: number): string {
+  if (str.length <= length) {
+    return str;
+  }
+  return str.substr(0, length - 1);
+}
+
 export function successResponse<T>(result: T): SuccessResponse<T> {
   return {
     result: result,


### PR DESCRIPTION
This PR handles the 30 character password length constraint that is imposed by Sierra. To handle this, a password provided is truncated to 30 characters in length if the password is greater than 30 characters. Auth0 itself does not impose password length limitations, but all passwords are effectively truncated to 72 characters to comply with the underlying bcrypt algorithm.