### PR TITLE
Copy schemas from build layer of AMS image

### DIFF
--- a/packages/account-management/Dockerfile
+++ b/packages/account-management/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=build /home/node/app/package.json /home/node/app/package.json
 COPY --from=build /home/node/app/yarn.lock /home/node/app/yarn.lock
 COPY --from=modules /home/node/app/node_modules /home/node/app/node_modules
 COPY --from=build /home/node/app/lib /home/node/app/lib
-COPY ./schemas /home/node/app/schemas
+COPY --from=build /home/node/app/schemas /home/node/app/schemas
 COPY ./webpack.frontend.js /home/node/app/webpack.frontend.js
 COPY ./ecosystem.config.js /home/node/app/ecosystem.config.js
 


### PR DESCRIPTION
Previously, we were copying an empty folder from the git repo into the final layer of the AMS image instead of the folder produced by the build with the generated schemas. This meant that any attempt to call the FE API endpoint to create the account was erroring due to the missing files.