### PR TITLE
Add Current Password verification field to Change Password form

### DIFF
--- a/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
+++ b/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
@@ -9,6 +9,7 @@ import { PasswordInput } from '../Shared/PasswordInput';
 const passwordPolicy = /(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*/;
 
 export const PasswordForm: React.FC = () => {
+  const [currentPassword, setCurrentPassword] = useState<string>('');
   const [newPassword, setNewPassword] = useState<string>('');
   const [confirmation, setConfirmation] = useState<string>('');
 
@@ -22,14 +23,11 @@ export const PasswordForm: React.FC = () => {
   return (
     <>
       <h1 className="font-wb font-size-4">Change your password using the form below.</h1>
+      <SpacingComponent />
       <form>
+        <PasswordInput label="Current password" value={currentPassword} setValue={setCurrentPassword} />
         <SpacingComponent />
-        <PasswordInput
-          label="Type new password"
-          value={newPassword}
-          setValue={setNewPassword}
-          pattern={passwordPolicy}
-        />
+        <PasswordInput label="New password" value={newPassword} setValue={setNewPassword} pattern={passwordPolicy} />
         {!isValid && (
           <ErrorMessage>
             The password you have entered does not meet the password policy. Please enter a password with at least 8
@@ -40,7 +38,7 @@ export const PasswordForm: React.FC = () => {
         <PasswordInput label="Retype new password" value={confirmation} setValue={setConfirmation} />
         {!isConfirmed && <ErrorMessage>The passwords you entered did not match.</ErrorMessage>}
         <SpacingComponent />
-        <SolidButton disabled={!isValid} onClick={updatePassword}>
+        <SolidButton disabled={!isValid || !isConfirmed} onClick={updatePassword}>
           Update Password
         </SolidButton>
         <input type="submit" value="Submit" hidden={true} />

--- a/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
+++ b/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
@@ -1,20 +1,19 @@
 import React, { useState } from 'react';
 import { SolidButton } from '@weco/common/views/components/ButtonSolid/ButtonSolid';
-// @ts-ignore
-import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 
 import { ErrorMessage } from '../Shared/ErrorMessage';
+import { PasswordInput } from '../Shared/PasswordInput';
 
 // At least 8 characters, one uppercase, one lowercase and number
 const passwordPolicy = /(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*/;
 
 export const PasswordForm: React.FC = () => {
-  const [password, setPassword] = useState<string>();
-  const [confirmation, setConfirmation] = useState<string>();
+  const [newPassword, setNewPassword] = useState<string>('');
+  const [confirmation, setConfirmation] = useState<string>('');
 
-  const isValid = password && !passwordPolicy.test(password || '');
-  const isConfirmed = password === confirmation;
+  const isValid = newPassword && passwordPolicy.test(newPassword);
+  const isConfirmed = newPassword === confirmation;
 
   const updatePassword = () => {
     // Update Password
@@ -25,14 +24,10 @@ export const PasswordForm: React.FC = () => {
       <h1 className="font-wb font-size-4">Change your password using the form below.</h1>
       <form>
         <SpacingComponent />
-        <TextInput
-          placeholder=""
-          required={true}
-          aria-label="Type new password"
+        <PasswordInput
           label="Type new password"
-          value={password}
-          setValue={(value: string) => setPassword(value)}
-          type="password"
+          value={newPassword}
+          setValue={setNewPassword}
           pattern={passwordPolicy}
         />
         {!isValid && (
@@ -42,14 +37,7 @@ export const PasswordForm: React.FC = () => {
           </ErrorMessage>
         )}
         <SpacingComponent />
-        <TextInput
-          required={true}
-          aria-label="Retype new password"
-          label="Retype new password"
-          value={confirmation}
-          setValue={(value: string) => setConfirmation(value)}
-          type="password"
-        />
+        <PasswordInput label="Retype new password" value={confirmation} setValue={setConfirmation} />
         {!isConfirmed && <ErrorMessage>The passwords you entered did not match.</ErrorMessage>}
         <SpacingComponent />
         <SolidButton disabled={!isValid} onClick={updatePassword}>

--- a/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
+++ b/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-
+import React, { useState } from 'react';
 import { SolidButton } from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 // @ts-ignore
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
@@ -10,21 +9,12 @@ import { ErrorMessage } from '../Shared/ErrorMessage';
 // At least 8 characters, one uppercase, one lowercase and number
 const passwordPolicy = /(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*/;
 
-export const PasswordForm = () => {
-  const [pass, setPass] = useState<string>();
-  const [passCheck, setPassCheck] = useState<string>();
-  const [valid, setValid] = useState<boolean | undefined | ''>(false);
-  const [passwordsMatch, setPasswordsMatch] = useState(true);
+export const PasswordForm: React.FC = () => {
+  const [password, setPassword] = useState<string>();
+  const [confirmation, setConfirmation] = useState<string>();
 
-  useEffect(() => {
-    // check if password passes password policy
-    pass && !passwordPolicy.test(pass || '') ? setValid(false) : setValid(true);
-  }, [pass]);
-
-  useEffect(() => {
-    // check if password matches each other
-    pass === passCheck ? setPasswordsMatch(true) : setPasswordsMatch(false);
-  }, [passCheck]);
+  const isValid = password && !passwordPolicy.test(password || '');
+  const isConfirmed = password === confirmation;
 
   const updatePassword = () => {
     // Update Password
@@ -40,32 +30,29 @@ export const PasswordForm = () => {
           required={true}
           aria-label="Type new password"
           label="Type new password"
-          value={pass}
-          setValue={(value: string) => setPass(value)}
+          value={password}
+          setValue={(value: string) => setPassword(value)}
           type="password"
           pattern={passwordPolicy}
         />
-        {!valid ? (
+        {!isValid && (
           <ErrorMessage>
             The password you have entered does not meet the password policy. Please enter a password with at least 8
             characters, a combination of upper and lowercase letters and at least one number.
           </ErrorMessage>
-        ) : (
-          <></>
         )}
         <SpacingComponent />
         <TextInput
           required={true}
           aria-label="Retype new password"
           label="Reype new password"
-          value={passCheck}
-          setValue={(value: string) => setPassCheck(value)}
+          value={confirmation}
+          setValue={(value: string) => setConfirmation(value)}
           type="password"
-          pattern={passwordPolicy}
         />
-        {!passwordsMatch ? <ErrorMessage>The passwords you entered did not match.</ErrorMessage> : <></>}
+        {!isConfirmed && <ErrorMessage>The passwords you entered did not match.</ErrorMessage>}
         <SpacingComponent />
-        <SolidButton disabled={!valid} onClick={updatePassword}>
+        <SolidButton disabled={!isValid} onClick={updatePassword}>
           Update Password
         </SolidButton>
         <input type="submit" value="Submit" hidden={true} />

--- a/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
+++ b/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
@@ -34,6 +34,12 @@ export const PasswordForm: React.FC = () => {
             characters, a combination of upper and lowercase letters and at least one number.
           </ErrorMessage>
         )}
+        <ul>
+          <li className="font-hnl font-size-6">One lowercase character</li>
+          <li className="font-hnl font-size-6">One uppercase character</li>
+          <li className="font-hnl font-size-6">One number</li>
+          <li className="font-hnl font-size-6">8 characters minimum</li>
+        </ul>
         <SpacingComponent />
         <PasswordInput label="Retype new password" value={confirmation} setValue={setConfirmation} />
         {!isConfirmed && <ErrorMessage>The passwords you entered did not match.</ErrorMessage>}

--- a/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
+++ b/packages/account-management/src/frontend/AccountManagement/PasswordForm.tsx
@@ -45,7 +45,7 @@ export const PasswordForm: React.FC = () => {
         <TextInput
           required={true}
           aria-label="Retype new password"
-          label="Reype new password"
+          label="Retype new password"
           value={confirmation}
           setValue={(value: string) => setConfirmation(value)}
           type="password"

--- a/packages/account-management/src/frontend/Shared/PasswordInput.tsx
+++ b/packages/account-management/src/frontend/Shared/PasswordInput.tsx
@@ -18,6 +18,7 @@ const IconWrapper = styled.div`
 `;
 
 type PasswordInputProps = {
+  label?: string;
   value: string | undefined;
   setValue: (value: string) => void;
   pattern?: RegExp;
@@ -27,6 +28,7 @@ type PasswordInputProps = {
 };
 
 export const PasswordInput: React.FC<PasswordInputProps> = (props) => {
+  const { label = 'Password' } = props;
   const [showPassword, setShowPassword] = useState<boolean>(false);
 
   const toggleShowPassword = () => setShowPassword(!showPassword);
@@ -39,8 +41,8 @@ export const PasswordInput: React.FC<PasswordInputProps> = (props) => {
       <TextInput
         placeholder=""
         required={true}
-        aria-label="Password"
-        label="Password"
+        aria-label={label}
+        label={label}
         type={showPassword ? 'text' : 'password'}
         style={{ width: '100%' }}
         {...props}


### PR DESCRIPTION
The validation logic here seems ok to me, but the UX isn't great as the new password validation happens before the user has started typing.

The logic behind showing that "not valid" message is quite fiddly, and I'd rather write some unit tests than fiddle with it any further. Installing and configuring a UI testing framework isn't a trivial piece of work, and it shouldn't hold up this ticket. This PR meets the requirements as defined.