### PR TITLE
Minor fixes to UserInfo attribute release and data models

### DIFF
--- a/infra/scoped/api-documentation/users/get-param-sort.json
+++ b/infra/scoped/api-documentation/users/get-param-sort.json
@@ -1,3 +1,3 @@
 {
-  "description": "The field to order the search query by. Valid values are `name`, `email`, `lastLogin` and `userId`."
+  "description": "The field to order the search query by. Valid values are `userId`, `name`, `email`, `lastLogin` and `locked`."
 }

--- a/models/user-list.json
+++ b/models/user-list.json
@@ -50,7 +50,7 @@
       "type": "array",
       "items": {
         "properties": {
-          "patronId": {
+          "userId": {
             "type": "number",
             "minimum": 0,
             "multipleOf": 1.0

--- a/models/user-list.json
+++ b/models/user-list.json
@@ -61,25 +61,27 @@
           },
           "firstName": {
             "type": "string",
-            "minLength": 1
           },
           "lastName": {
             "type": "string",
-            "minLength": 1
           },
           "email": {
             "type": "string",
-            "format": "email"
+            "format": "email",
+            "minLength": 1
           },
           "emailValidated": {
-            "type": "boolean"
+            "type": "boolean",
+            "minLength": 1
           },
           "locked": {
-            "type": "boolean"
+            "type": "boolean",
+            "minLength": 1
           },
           "creationDate": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "minLength": 1
           },
           "lastLogin": {
             "type": "string",

--- a/models/user-list.json
+++ b/models/user-list.json
@@ -60,10 +60,10 @@
             "minLength": 1
           },
           "firstName": {
-            "type": "string",
+            "type": "string"
           },
           "lastName": {
-            "type": "string",
+            "type": "string"
           },
           "email": {
             "type": "string",

--- a/models/user.json
+++ b/models/user.json
@@ -13,26 +13,28 @@
       "minLength": 1
     },
     "firstName": {
-      "type": "string",
-      "minLength": 1
+      "type": "string"
     },
     "lastName": {
-      "type": "string",
-      "minLength": 1
+      "type": "string"
     },
     "email": {
       "type": "string",
-      "format": "email"
+      "format": "email",
+      "minLength": 1
     },
     "emailValidated": {
-      "type": "boolean"
+      "type": "boolean",
+      "minLength": 1
     },
     "locked": {
-      "type": "boolean"
+      "type": "boolean",
+      "minLength": 1
     },
     "creationDate": {
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "minLength": 1
     },
     "lastLogin": {
       "type": "string",

--- a/packages/apps/api/src/models/user.ts
+++ b/packages/apps/api/src/models/user.ts
@@ -3,7 +3,7 @@ import { PatronRecord } from '@weco/sierra-client/lib/patron';
 
 export function toUser(patronRecord: PatronRecord, auth0Profile: Auth0Profile): User {
   return {
-    patronId: patronRecord.recordNumber,
+    userId: auth0Profile.userId,
     barcode: patronRecord.barcode,
     firstName: auth0Profile.firstName,
     lastName: auth0Profile.lastName,
@@ -18,15 +18,15 @@ export function toUser(patronRecord: PatronRecord, auth0Profile: Auth0Profile): 
 }
 
 interface User {
-  patronId: number,
+  userId: number,
   barcode: string,
-  firstName: string,
-  lastName: string,
+  firstName: string | null,
+  lastName: string | null,
   email: string,
   emailValidated: boolean,
   locked: boolean,
   creationDate: string,
-  lastLogin: string,
-  lastLoginIp: string,
+  lastLogin: string | null,
+  lastLoginIp: string | null,
   totalLogins: number
 }

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -89,8 +89,8 @@ export interface Auth0Profile extends Auth0UserInfo {
   emailValidated: boolean,
   locked: boolean,
   creationDate: string,
-  lastLogin: string,
-  lastLoginIp: string,
+  lastLogin: string | null,
+  lastLoginIp: string | null,
   totalLogins: number
 }
 


### PR DESCRIPTION
- Patron data is now only released through a `/userinfo` call if the `patron:read` scope was provided when the access token was generated.
- `patronId` has been renamed to `userId` in API response models (these two are equivalent).
- Validating that Auth0 is providing the required data to build up API responses - this is usually indicative of a lack of scopes attached to the provided access token.
- Certain fields (`firstName`, `lastName`, `lastLoginDate` and `lastLoginIp`) are optional in Auth0. This is now reflected in the API documentation.