### PR TITLE
Updated infrastructure to allow separate email users for different environments

### DIFF
--- a/infra/scoped/parameters.tf
+++ b/infra/scoped/parameters.tf
@@ -144,8 +144,21 @@ resource "aws_ssm_parameter" "auth0_email_from_name" {
   )
 }
 
-data "aws_ssm_parameter" "auth0_email_from_user" {
-  name = "identity-auth0_email_from_user"
+resource "aws_ssm_parameter" "auth0_email_from_user" {
+  name  = "identity-auth0_email_from_user-${terraform.workspace}"
+  type  = "String"
+  value = var.ssm_parameter_placeholder
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-auth0_email_from_user-${terraform.workspace}"
+    }
+  )
 }
 
 data "aws_ssm_parameter" "auth0_email_from_domain" {

--- a/infra/scoped/variables.tf
+++ b/infra/scoped/variables.tf
@@ -21,7 +21,7 @@ locals {
   # Auth0
   auth0_hostname      = "${aws_ssm_parameter.hostname_prefix.value}.${data.aws_ssm_parameter.hostname.value}"
   auth0_endpoint      = "https://${local.auth0_hostname}"
-  auth0_email_address = "${data.aws_ssm_parameter.auth0_email_from_user.value}@${data.aws_ssm_parameter.auth0_email_from_domain.value}"
+  auth0_email_address = "${aws_ssm_parameter.auth0_email_from_user.value}@${data.aws_ssm_parameter.auth0_email_from_domain.value}"
   auth0_email_from    = "${aws_ssm_parameter.auth0_email_from_name.value} <${local.auth0_email_address}>"
 
   # Account Management System

--- a/infra/static/parameters.tf
+++ b/infra/static/parameters.tf
@@ -36,23 +36,6 @@ resource "aws_ssm_parameter" "auth0_email_from_domain" {
   )
 }
 
-resource "aws_ssm_parameter" "auth0_email_from_user" {
-  name  = "identity-auth0_email_from_user"
-  type  = "String"
-  value = var.ssm_parameter_placeholder
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = merge(
-    local.common_tags,
-    {
-      "Name" = "identity-auth0_email_from_user"
-    }
-  )
-}
-
 # API Gateway
 
 resource "aws_ssm_parameter" "api_gateway_log_format" {


### PR DESCRIPTION
This PR allows the user component of the email address used for outbound emails to be configured on a per-environment basis.