### PR TITLE
Implements caching mechanism for '/userinfo' lookups in API Authorizer

### DIFF
--- a/infra/scoped/elasticache.tf
+++ b/infra/scoped/elasticache.tf
@@ -1,0 +1,27 @@
+resource "aws_elasticache_subnet_group" "access_token_cache" {
+  name = "identity-subnet-group-access-token-cache-${terraform.workspace}"
+  subnet_ids = [
+    aws_subnet.private_1.id,
+    aws_subnet.private_2.id,
+    aws_subnet.private_3.id
+  ]
+}
+
+resource "aws_elasticache_cluster" "access_token_cache" {
+  cluster_id           = "identity-access-token-cache-${terraform.workspace}"
+  engine               = "redis"
+  node_type            = "cache.t2.micro"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis6.x"
+  engine_version       = "6.0.5"
+  port                 = 6379
+
+  subnet_group_name = aws_elasticache_subnet_group.access_token_cache.name
+
+  tags = merge(
+    local.common_tags,
+    {
+      "name" = "identity-access-token-cache-${terraform.workspace}"
+    }
+  )
+}

--- a/infra/scoped/elasticache.tf
+++ b/infra/scoped/elasticache.tf
@@ -16,8 +16,8 @@ resource "aws_elasticache_replication_group" "access_token_cache" {
   engine                = "redis"
   engine_version        = "6.x"
   parameter_group_name  = "default.redis6.x"
-  node_type             = "cache.t2.micro"
-  number_cache_clusters = 2
+  node_type             = aws_ssm_parameter.redis_access_token_cache_node_type.value
+  number_cache_clusters = aws_ssm_parameter.redis_access_token_cache_number_cache_clusters.value
   port                  = 6379
 
   subnet_group_name = aws_elasticache_subnet_group.access_token_cache.name
@@ -28,7 +28,9 @@ resource "aws_elasticache_replication_group" "access_token_cache" {
 
   lifecycle {
     ignore_changes = [
-      engine_version # We have to specify '6.x' above, but after creation this will change to a specific version
+      # We have to specify '6.x' above, but after creation this will change to a specific version and breaks when
+      # `apply'ing.
+      engine_version
     ]
   }
 

--- a/infra/scoped/iam.tf
+++ b/infra/scoped/iam.tf
@@ -58,6 +58,11 @@ resource "aws_iam_role_policy_attachment" "identity_api_gateway_lambda_policy" {
   policy_arn = aws_iam_policy.identity_api_gateway_lambda_policy.arn
 }
 
+resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRole" {
+  role       = aws_iam_role.identity_api_gateway_lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
 # SES
 
 resource "aws_iam_user" "auth0_email" {

--- a/infra/scoped/lambda.tf
+++ b/infra/scoped/lambda.tf
@@ -28,6 +28,7 @@ resource "aws_lambda_function" "authorizer" {
       AUTH0_CLIENT_SECRET = auth0_client.api_gateway_identity.client_secret,
       REDIS_HOST          = aws_elasticache_replication_group.access_token_cache.primary_endpoint_address
       REDIS_PORT          = aws_elasticache_replication_group.access_token_cache.port
+      REDIS_CACHE_TTL     = aws_ssm_parameter.redis_access_token_cache_ttl.value
     }
   }
 

--- a/infra/scoped/lambda.tf
+++ b/infra/scoped/lambda.tf
@@ -1,4 +1,4 @@
-# stubs/authorizer.js
+# packages/apps/api-authorizer
 
 resource "aws_lambda_function" "authorizer" {
   function_name = "identity-authorizer-${terraform.workspace}"
@@ -6,6 +6,19 @@ resource "aws_lambda_function" "authorizer" {
   role          = aws_iam_role.identity_api_gateway_lambda_role.arn
   runtime       = "nodejs12.x"
   filename      = "data/empty.zip"
+
+  vpc_config {
+    subnet_ids = [
+      aws_subnet.private_1.id,
+      aws_subnet.private_2.id,
+      aws_subnet.private_3.id,
+    ]
+
+    security_group_ids = [
+      aws_security_group.local.id,
+      aws_security_group.egress.id
+    ]
+  }
 
   environment {
     variables = {
@@ -56,6 +69,19 @@ resource "aws_lambda_function" "api" {
   runtime       = "nodejs12.x"
   filename      = "data/empty.zip"
   timeout       = 10
+
+  vpc_config {
+    subnet_ids = [
+      aws_subnet.private_1.id,
+      aws_subnet.private_2.id,
+      aws_subnet.private_3.id,
+    ]
+
+    security_group_ids = [
+      aws_security_group.local.id,
+      aws_security_group.egress.id
+    ]
+  }
 
   environment {
     variables = {

--- a/infra/scoped/lambda.tf
+++ b/infra/scoped/lambda.tf
@@ -22,15 +22,12 @@ resource "aws_lambda_function" "authorizer" {
 
   environment {
     variables = {
-      SIERRA_API_ROOT      = aws_ssm_parameter.sierra_api_hostname.value,
-      SIERRA_CLIENT_KEY    = data.external.sierra_api_credentials.result.SierraAPIKey
-      SIERRA_CLIENT_SECRET = data.external.sierra_api_credentials.result.SierraAPISecret
-      AUTH0_API_ROOT       = local.auth0_endpoint
-      AUTH0_API_AUDIENCE   = auth0_client_grant.api_gateway_identity.audience,
-      AUTH0_CLIENT_ID      = auth0_client.api_gateway_identity.client_id,
-      AUTH0_CLIENT_SECRET  = auth0_client.api_gateway_identity.client_secret,
-      EMAIL_FROM_ADDRESS   = local.auth0_email_from,
-      EMAIL_ADMIN_ADDRESS  = aws_ssm_parameter.email_admin_address.value
+      AUTH0_API_ROOT      = local.auth0_endpoint
+      AUTH0_API_AUDIENCE  = auth0_client_grant.api_gateway_identity.audience,
+      AUTH0_CLIENT_ID     = auth0_client.api_gateway_identity.client_id,
+      AUTH0_CLIENT_SECRET = auth0_client.api_gateway_identity.client_secret,
+      REDIS_HOST          = aws_elasticache_replication_group.access_token_cache.primary_endpoint_address
+      REDIS_PORT          = aws_elasticache_replication_group.access_token_cache.port
     }
   }
 

--- a/infra/scoped/parameters.tf
+++ b/infra/scoped/parameters.tf
@@ -406,6 +406,40 @@ resource "aws_ssm_parameter" "email_admin_address" {
 
 # Redis - Access Token Cache
 
+resource "aws_ssm_parameter" "redis_access_token_cache_node_type" {
+  name  = "identity-redis_access_token_cache_node_type-${terraform.workspace}"
+  type  = "String"
+  value = var.ssm_parameter_placeholder
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-redis_access_token_cache_node_type-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_ssm_parameter" "redis_access_token_cache_number_cache_clusters" {
+  name  = "identity-redis_access_token_cache_number_cache_clusters-${terraform.workspace}"
+  type  = "String"
+  value = var.ssm_parameter_placeholder
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-redis_access_token_cache_number_cache_clusters-${terraform.workspace}"
+    }
+  )
+}
+
 resource "aws_ssm_parameter" "redis_access_token_cache_ttl" {
   name  = "identity-redis_access_token_cache_ttl-${terraform.workspace}"
   type  = "String"

--- a/infra/scoped/parameters.tf
+++ b/infra/scoped/parameters.tf
@@ -403,3 +403,22 @@ resource "aws_ssm_parameter" "email_admin_address" {
     }
   )
 }
+
+# Redis - Access Token Cache
+
+resource "aws_ssm_parameter" "redis_access_token_cache_ttl" {
+  name  = "identity-redis_access_token_cache_ttl-${terraform.workspace}"
+  type  = "String"
+  value = var.ssm_parameter_placeholder
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-redis_access_token_cache_ttl-${terraform.workspace}"
+    }
+  )
+}

--- a/infra/scoped/security-groups.tf
+++ b/infra/scoped/security-groups.tf
@@ -1,0 +1,42 @@
+# Local
+
+resource "aws_security_group" "local" {
+  name   = "identity-local-${terraform.workspace}"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-local-${terraform.workspace}"
+    }
+  )
+}
+
+# Egress
+
+resource "aws_security_group" "egress" {
+  name   = "identity-egress-${terraform.workspace}"
+  vpc_id = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-egress-${terraform.workspace}"
+    }
+  )
+}

--- a/infra/scoped/variables.tf
+++ b/infra/scoped/variables.tf
@@ -45,6 +45,36 @@ variable "tag_managed_by" {
   default = "Terraform"
 }
 
+# AWS VPC
+
+variable "network_cidr" {
+  default = "10.0.0.0/16"
+}
+
+variable "network_azs" {
+  default = [
+    "eu-west-1a",
+    "eu-west-1b",
+    "eu-west-1c"
+  ]
+}
+
+variable "network_public_cidrs" {
+  default = [
+    "10.0.101.0/24",
+    "10.0.102.0/24",
+    "10.0.103.0/24"
+  ]
+}
+
+variable "network_private_cidrs" {
+  default = [
+    "10.0.1.0/24",
+    "10.0.2.0/24",
+    "10.0.3.0/24"
+  ]
+}
+
 # SSM Parameters
 
 variable "ssm_parameter_placeholder" {

--- a/infra/scoped/vpc.tf
+++ b/infra/scoped/vpc.tf
@@ -1,0 +1,212 @@
+# VPC
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.network_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-vpc-${terraform.workspace}"
+    }
+  )
+}
+
+# Internet Gateway
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-internet-gateway-${terraform.workspace}"
+    }
+  )
+}
+
+# NAT Gateway
+
+resource "aws_eip" "nat_gateway" {
+  vpc = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-nat-gateway-ip-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat_gateway.id
+  subnet_id     = aws_subnet.public_1.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-nat-gateway-${terraform.workspace}"
+    }
+  )
+}
+
+# Public Routes
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-public-route-table-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_route" "public" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.main.id
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+# Private Routes
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-private-route-table-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_route" "private" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.main.id
+}
+
+# Public Subnets
+
+resource "aws_subnet" "public_1" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.network_public_cidrs[0]
+  availability_zone       = var.network_azs[0]
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-public-subnet-1-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_route_table_association" "public_1" {
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_1.id
+}
+
+resource "aws_subnet" "public_2" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.network_public_cidrs[1]
+  availability_zone       = var.network_azs[1]
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-public-subnet-2-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_route_table_association" "public_2" {
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_2.id
+}
+
+resource "aws_subnet" "public_3" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.network_public_cidrs[2]
+  availability_zone       = var.network_azs[2]
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-public-subnet-3-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_route_table_association" "public_3" {
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_3.id
+}
+
+# Private Subnets
+
+resource "aws_subnet" "private_1" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.network_private_cidrs[0]
+  availability_zone       = var.network_azs[0]
+  map_public_ip_on_launch = false
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-private-subnet-1-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_route_table_association" "private_1" {
+  route_table_id = aws_route_table.private.id
+  subnet_id      = aws_subnet.private_1.id
+}
+
+resource "aws_subnet" "private_2" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.network_private_cidrs[1]
+  availability_zone       = var.network_azs[1]
+  map_public_ip_on_launch = false
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-private-subnet-2-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_route_table_association" "private_2" {
+  route_table_id = aws_route_table.private.id
+  subnet_id      = aws_subnet.private_2.id
+}
+
+resource "aws_subnet" "private_3" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.network_private_cidrs[2]
+  availability_zone       = var.network_azs[2]
+  map_public_ip_on_launch = false
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "identity-private-subnet-3-${terraform.workspace}"
+    }
+  )
+}
+
+resource "aws_route_table_association" "private_3" {
+  route_table_id = aws_route_table.private.id
+  subnet_id      = aws_subnet.private_3.id
+}

--- a/packages/apps/api-authorizer/package.json
+++ b/packages/apps/api-authorizer/package.json
@@ -11,7 +11,9 @@
     "devDependencies": {
         "@types/aws-lambda": "^8.10.71",
         "@types/node": "^14.14.25",
+        "@types/redis": "^2.8.28",
         "@weco/auth0-client": "*",
+        "redis": "^3.0.2",
         "ts-node": "^9.1.1",
         "typescript": "^4.1.3"
     }

--- a/packages/apps/api-authorizer/package.json
+++ b/packages/apps/api-authorizer/package.json
@@ -11,8 +11,8 @@
     "devDependencies": {
         "@types/aws-lambda": "^8.10.71",
         "@types/node": "^14.14.25",
-        "@types/redis": "^2.8.28",
         "@weco/auth0-client": "*",
+        "handy-redis": "^2.2.1",
         "redis": "^3.0.2",
         "ts-node": "^9.1.1",
         "typescript": "^4.1.3"

--- a/packages/apps/api-authorizer/src/index.ts
+++ b/packages/apps/api-authorizer/src/index.ts
@@ -15,7 +15,7 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
     host: process.env.REDIS_HOST!,
     port: Number(process.env.REDIS_PORT!)
   });
-  const redisGet: (key: string) => Promise<string | null> = <(key: string) => Promise<string | null>>promisify(redisClient.get).bind(redisClient);
+  const redisGet: (key: string) => Promise<Auth0UserInfo | null> = <(key: string) => Promise<Auth0UserInfo | null>>promisify(redisClient.get).bind(redisClient);
   const redisSet: (key: string, value: string, mode: string, duration: number) => Promise<'OK' | undefined> = <(key: string, value: string, mode: string, duration: number) => Promise<'OK' | undefined>>promisify(redisClient.set).bind(redisClient);
 
   if (!event.headers?.Authorization) {
@@ -33,7 +33,7 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
   let auth0UserInfo: Auth0UserInfo | null = await redisGet(accessToken).then(data => {
     if (data) {
       console.log('Cache hit for access token [' + accessToken + ']: [' + data + ']');
-      return toAuth0UserInfo(data);
+      return data;
     } else {
       return null;
     }

--- a/packages/apps/api-authorizer/src/index.ts
+++ b/packages/apps/api-authorizer/src/index.ts
@@ -15,7 +15,7 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
     host: process.env.REDIS_HOST!,
     port: Number(process.env.REDIS_PORT!)
   });
-  const redisGet: (key: string) => Promise<Auth0UserInfo | null> = <(key: string) => Promise<Auth0UserInfo | null>>promisify(redisClient.get).bind(redisClient);
+  const redisGet: (key: string) => Promise<string | null> = <(key: string) => Promise<string | null>>promisify(redisClient.get).bind(redisClient);
   const redisSet: (key: string, value: string, mode: string, duration: number) => Promise<'OK' | undefined> = <(key: string, value: string, mode: string, duration: number) => Promise<'OK' | undefined>>promisify(redisClient.set).bind(redisClient);
 
   if (!event.headers?.Authorization) {
@@ -33,7 +33,7 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
   let auth0UserInfo: Auth0UserInfo | null = await redisGet(accessToken).then(data => {
     if (data) {
       console.log('Cache hit for access token [' + accessToken + ']: [' + data + ']');
-      return data;
+      return JSON.parse(data) as Auth0UserInfo;
     } else {
       return null;
     }

--- a/packages/apps/api-authorizer/src/index.ts
+++ b/packages/apps/api-authorizer/src/index.ts
@@ -4,6 +4,8 @@ import { APIResponse, ResponseStatus } from '@weco/identity-common';
 import { APIGatewayAuthorizerResult, APIGatewayRequestAuthorizerEvent } from 'aws-lambda';
 import { createNodeRedisClient, WrappedNodeRedisClient } from "handy-redis";
 
+// Place these resources outside of the handler itself, so they can be reused between invocations.
+
 const auth0Client: Auth0Client = new Auth0Client(
   process.env.AUTH0_API_ROOT!, process.env.AUTH0_API_AUDIENCE!, process.env.AUTH0_CLIENT_ID!, process.env.AUTH0_CLIENT_SECRET!
 );
@@ -20,6 +22,7 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
     return buildAuthorizerResult('user', 'Deny', event.methodArn);
   }
 
+  // Start by extracting the access token from the 'Authorization' header.
   const authorizationHeader: string = event.headers.Authorization;
   const accessToken: string | null = extractAccessToken(authorizationHeader);
   if (!accessToken) {
@@ -27,6 +30,16 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
     return buildAuthorizerResult(authorizationHeader, 'Deny', event.methodArn);
   }
 
+  /*
+   * 1. Using the given access token, query the Redis cache for an existing entry.
+   * 2. If one is found, we assume the token is still valid and re-use the associated user information.
+   * 3. Otherwise, query the Auth0 API to test for validity and fetch the corresponding user information.
+   * 4. If the query was successful, store the user information in the Redis cache keyed against the access token.
+   *
+   * When the entry is inserted into the cache, it has a TTL defined by 'REDIS_CACHE_TTL'. Essentially, this value
+   * represents the maximum amount of time (in seconds) that a token can be expired / revoked by Auth0 before we detect
+   * that in this Lambda Function.
+   */
   let auth0UserInfo: Auth0UserInfo | null = await cacheLookup(accessToken);
   if (!auth0UserInfo) {
     const auth0Validate: APIResponse<Auth0UserInfo> = await auth0Client.validateAccessToken(accessToken);
@@ -43,6 +56,8 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
     await cacheInsert(accessToken, auth0UserInfo);
   }
 
+  // At this point, we have a valid access token and have a handle on the caller user information. Now we determine if
+  // the user has access to the resource they are operating on.
   if (!validateRequest(auth0UserInfo, event.resource, <ResourceAclMethod>event.httpMethod, event.pathParameters)) {
     console.log('Access token [' + accessToken + '] for user [' + JSON.stringify(auth0UserInfo) + '] cannot operate on [' + event.httpMethod + ' ' + event.resource + '] with path parameters [' + event.pathParameters + ']');
     return buildAuthorizerResult(auth0UserInfo.userId, 'Deny', event.methodArn);
@@ -52,7 +67,7 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
 }
 
 async function cacheLookup(accessToken: string): Promise<Auth0UserInfo | null> {
-  return await redisClient.get(accessToken).then(value => {
+  return redisClient.get(accessToken).then(value => {
     if (value) {
       console.log('Cache hit for access token [' + accessToken + '] with value [' + value + ']');
       return JSON.parse(value) as Auth0UserInfo;
@@ -64,10 +79,12 @@ async function cacheLookup(accessToken: string): Promise<Auth0UserInfo | null> {
 }
 
 async function cacheInsert(accessToken: string, auth0UserInfo: Auth0UserInfo): Promise<string | null> {
-  const value = JSON.stringify(auth0UserInfo);
-  return await redisClient.set(accessToken, value, ['EX', 60]).then(result => {
+  const value: string = JSON.stringify(auth0UserInfo);
+  const ttl: number = Number(process.env.REDIS_CACHE_TTL!);
+  // 'EX' is the expiration (i.e. TTL) in seconds of the cache entry. We could also use 'PX' to provide the value in milliseconds.
+  return redisClient.set(accessToken, value, ['EX', ttl]).then(result => {
     console.log('Cache put for access token [' + accessToken + '] with value [' + value + ']: [' + result + ']');
-    return value;
+    return value; // AFAICT this is always 'OK' for a successful operation
   });
 }
 

--- a/packages/apps/api-authorizer/src/index.ts
+++ b/packages/apps/api-authorizer/src/index.ts
@@ -65,7 +65,7 @@ async function cacheLookup(accessToken: string): Promise<Auth0UserInfo | null> {
 
 async function cacheInsert(accessToken: string, auth0UserInfo: Auth0UserInfo): Promise<string | null> {
   const value = JSON.stringify(auth0UserInfo);
-  return await redisClient.set(accessToken, value).then(result => {
+  return await redisClient.set(accessToken, value, ['EX', 60]).then(result => {
     console.log('Cache put for access token [' + accessToken + '] with value [' + value + ']: [' + result + ']');
     return value;
   });

--- a/packages/apps/api-authorizer/src/index.ts
+++ b/packages/apps/api-authorizer/src/index.ts
@@ -15,8 +15,8 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
     host: process.env.REDIS_HOST!,
     port: Number(process.env.REDIS_PORT!)
   });
-  const redisGet = <(key: string) => Promise<string | null>>promisify(redisClient.get).bind(redisClient);
-  const redisSet = <(key: string, value: string, mode: string, duration: number) => Promise<'OK' | undefined>>promisify(redisClient.set).bind(redisClient);
+  const redisGet: (key: string) => Promise<string | null> = <(key: string) => Promise<string | null>>promisify(redisClient.get).bind(redisClient);
+  const redisSet: (key: string, value: string, mode: string, duration: number) => Promise<'OK' | undefined> = <(key: string, value: string, mode: string, duration: number) => Promise<'OK' | undefined>>promisify(redisClient.set).bind(redisClient);
 
   if (!event.headers?.Authorization) {
     console.log('Authorization header is not present on request');
@@ -30,9 +30,13 @@ export async function lambdaHandler(event: APIGatewayRequestAuthorizerEvent): Pr
     return buildAuthorizerResult(authorizationHeader, 'Deny', event.methodArn);
   }
 
-  let auth0UserInfo: Auth0UserInfo = await redisGet(accessToken).then(data => {
-    console.log('Cache hit for access token [' + accessToken + ']: [' + data + ']');
-    return toAuth0UserInfo(data);
+  let auth0UserInfo: Auth0UserInfo | null = await redisGet(accessToken).then(data => {
+    if (data) {
+      console.log('Cache hit for access token [' + accessToken + ']: [' + data + ']');
+      return toAuth0UserInfo(data);
+    } else {
+      return null;
+    }
   });
 
   if (!auth0UserInfo) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,6 +2046,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/redis@^2.8.28":
+  version "2.8.28"
+  resolved "https://registry.yarnpkg.com/@types/redis/-/redis-2.8.28.tgz#5862b2b64aa7f7cbc76dafd7e6f06992b52c55e3"
+  integrity sha512-8l2gr2OQ969ypa7hFOeKqtFoY70XkHxISV0pAwmQ2nm6CSPb1brmTmqJCGGrekCo+pAZyWlNXr+Kvo6L/1wijA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/serve-static@*":
   version "1.13.9"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.9.tgz#aacf28a85a05ee29a11fb7c3ead935ac56f33e4e"
@@ -3520,6 +3527,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+denque@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
+  integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -7365,6 +7377,33 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redis-commands@^1.5.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
+  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
+
+redis@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-3.0.2.tgz#bd47067b8a4a3e6a2e556e57f71cc82c7360150a"
+  integrity sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==
+  dependencies:
+    denque "^1.4.1"
+    redis-commands "^1.5.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,7 +2046,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/redis@^2.8.28":
+"@types/redis@^2.8.27":
   version "2.8.28"
   resolved "https://registry.yarnpkg.com/@types/redis/-/redis-2.8.28.tgz#5862b2b64aa7f7cbc76dafd7e6f06992b52c55e3"
   integrity sha512-8l2gr2OQ969ypa7hFOeKqtFoY70XkHxISV0pAwmQ2nm6CSPb1brmTmqJCGGrekCo+pAZyWlNXr+Kvo6L/1wijA==
@@ -4527,6 +4527,13 @@ handlebars@^4.7.6:
     wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
+
+handy-redis@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/handy-redis/-/handy-redis-2.2.1.tgz#33f4293dffba7e0c2b198c4a4ce7cd4a832b5ecc"
+  integrity sha512-Kmz9HhdAA9tGV1b1R6m3AJ8GcC+r/0uzyiTia39Q8tseJJc4kOwGGQr7cfPppD/xlO2ENE5IK+ToRahLuX1JVg==
+  dependencies:
+    "@types/redis" "^2.8.27"
 
 har-schema@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Auth0 imposes a limit of 5 requests per minute against the `/userinfo` endpoint for a given user ID. This presents a challenge, as our API Authorizer implementation depends on the `/userinfo` endpoint to check for access token validity and to retrieve the callers user information to identify them. This occurs on every call the API.

To avoid hitting this limit, this PR introduces a caching mechanism using AWS Elasticache's Redis implementation. When an access token is successful retrieved from the `Authorization: Bearer ...` header, the Redis cache is first checked using the access token as a key. If an entry is found, the value is the user profile data for the caller, and the access token is assumed to be valid.

If no entry is found, the `/userinfo` endpoint is queried to determine the validity of the access token and, if valid, to retrieve the callers user profile. This data is then inserted into Redis with a configurable TTL (e.g. 60 seconds). Any subsequent call made to the API using the same access token in the TTL time period is serviced using the data in the cache.