### PR TITLE
Assume identity-developer role in provider/backend

### DIFF
--- a/infra/scoped/.terraform.lock.hcl
+++ b/infra/scoped/.terraform.lock.hcl
@@ -1,0 +1,111 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/alexkappa/auth0" {
+  version     = "0.16.1"
+  constraints = "~> 0.16.0"
+  hashes = [
+    "h1:Yuan3uU/eISWfu9f7JMG8WackUOMnrrh3LFywdxqMek=",
+    "zh:173017f420275c617881602a35fda7beb6e097d6d32fbdbb035046b4a90a4136",
+    "zh:2422e7e41fea5e9578e9fd5c71376ab48328141b90ffd7e2c0823d581b309563",
+    "zh:433c7cac260c7882d4f889d097907ea779fb7d890366109ca9c3d18ad056aac9",
+    "zh:4368896d4515a9e07c06d5ec761a2153be9a7b4f0dc2228414dd1d10a95d40a3",
+    "zh:4dcf47b68d30412ace73ba3e51c8a6cc93606426e65872c5d94d7f8d6a12efe5",
+    "zh:5666872e5bf24f5bb8a6e34fe1f76f32bf57ae042ae1d6988781f406145cb494",
+    "zh:85ddd1c107bfcdc54fbe5812f93961345a47b36ebf8a0588f507100e86389a8e",
+    "zh:a53c2db134e3bbf07762673f183527a9954ee9b0456435a36d5461f498cce314",
+    "zh:ae490c036433874fc7b447a414c172a4ad27a1bbcbb5a320e37dd359d3e3f73a",
+    "zh:cf9a19a3d36d159b624f47869ad8d7abc225f4e619121c5917c62dcfb9834ebf",
+    "zh:d6d09902c8de5480d3ecc4cf3a29ac4bb36975ab93b21a5d96ca0ab95a3d99d8",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.0.0"
+  constraints = "~> 2.0.0"
+  hashes = [
+    "h1:eOUi4EO4QTgPuz+gmD8xy2LTTxNfyc9txyc9PDARth8=",
+    "zh:1c3300a6686481ed0b3ce456949805b5c55f901b77108543046f12118a102914",
+    "zh:2d44bcc8a5ea3f2c2ff54ca4c4b273cdc3500ad8bb6929eec6722bb9d10a9714",
+    "zh:4be17c4e06a74ca30a3c9e88446e453ad16c493b2ddef872a6580dbfe618a1b4",
+    "zh:50c216a6c672b51d67ece37ce69c121acbcd5c8d24b899e876c61bc09989f69f",
+    "zh:90d6ad51fecab8d2f086aab9ed45020f1a9d3627dbc95edda11af8e3f87082d9",
+    "zh:d147427135330b4940a85a0f552e2c1f83a0d1ccdcc82c36a2d311b7f85dbd38",
+    "zh:dd4b8c0b113e37fd83ceab0f8a203ccfa39caaca5551c70a94fa61e900902932",
+    "zh:e30ef64a2ed0c2a6e8d1e29b8da8b05b4a303e256478a4b410af81c81cbcbc23",
+    "zh:e5a81379810d3e1f380b7145d0ecee4a69ab4e80184f77b66cd4411b86aca6a8",
+    "zh:f9a0a2a72721e7e047e83053173b3a68a7d53e2a22719cc2d9234dbee46c466c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.14.1"
+  constraints = "~> 3.14.0"
+  hashes = [
+    "h1:ADr5q/0e+ZLDWLRYA6jzbawTKInpnuJFafhUlM4PlQ8=",
+    "zh:12668d9cb947dbebefe4af454180021ae28510d875b77747a95d5f77a822120f",
+    "zh:2c6e383e722d5ef955ee3c8d50eae8cadd92d4d6b8900250333f683f69bb498c",
+    "zh:37b956ff025d8b52ff587f5a55c44eedcb646796195edcb57049735416fc2185",
+    "zh:66927ec7db6165f88b05fecb5ccbd63e9df73543acbde1d082b649213a301233",
+    "zh:775a65c29299ffc147444d901b43c6bbfa3415f02e3a6580bdf84d921c4c0cc0",
+    "zh:7edee181ff3bf3057cffe1cd5bee1d18942b5e1b89572a9df122ce14fbd299cc",
+    "zh:cbdd2fc43ecda1ca454ff74173a2a0676e0396414cc354a6562440387eff4942",
+    "zh:e03157a0a94128f71da039c124435ab23acc1d8ecdbe10637122c14eccb345b0",
+    "zh:fe32fa8bd8e27acf96f83b21561215c5a23e73e58b71b04f142bafd7a8dc399b",
+    "zh:feb3074875927342690a5302e453827588dd4882077137646e284096849774c2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.0.0"
+  constraints = "~> 2.0.0"
+  hashes = [
+    "h1:6S7hqjmUnoAZ5D/0F1VlJZKSJsUIBh7Ro0tLjGpKO0g=",
+    "zh:07949780dd6a1d43e7b46950f6e6976581d9724102cb5388d3411a1b6f476bde",
+    "zh:0a4f4636ff93f0644affa8474465dd8c9252946437ad025b28fc9f6603534a24",
+    "zh:0dd7e05a974c649950d1a21d7015d3753324ae52ebdd1744b144bc409ca4b3e8",
+    "zh:2b881032b9aa9d227ac712f614056d050bcdcc67df0dc79e2b2cb76a197059ad",
+    "zh:38feb4787b4570335459ca75a55389df1a7570bdca8cdf5df4c2876afe3c14b4",
+    "zh:40f7e0aaef3b1f4c2ca2bb1189e3fe9af8c296da129423986d1d99ccc8cfb86c",
+    "zh:56b361f64f0f0df5c4f958ae2f0e6f8ba192f35b720b9d3ae1be068fabcf73d9",
+    "zh:5fadb5880cd31c2105f635ded92b9b16f918c1dd989627a4ce62c04939223909",
+    "zh:61fa0be9c14c8c4109cfb7be8d54a80c56d35dbae49d3231cddb59831e7e5a4d",
+    "zh:853774bf97fbc4a784d5af5a4ca0090848430781ae6cfc586adeb48f7c44af79",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.0.1"
+  constraints = "~> 3.0.0"
+  hashes = [
+    "h1:0QaSbRBgBi8vI/8IRwec1INdOqBxXbgsSFElx1O4k4g=",
+    "zh:0d4f683868324af056a9eb2b06306feef7c202c88dbbe6a4ad7517146a22fb50",
+    "zh:4824b3c7914b77d41dfe90f6f333c7ac9860afb83e2a344d91fbe46e5dfbec26",
+    "zh:4b82e43712f3cf0d0cbc95b2cbcd409ba8f0dc7848fdfb7c13633c27468ed04a",
+    "zh:78b3a2b860c3ebc973a794000015f5946eb59b82705d701d487475406b2612f1",
+    "zh:88bc65197bd74ff408d147b32f0045372ae3a3f2a2fdd7f734f315d988c0e4a2",
+    "zh:91bd3c9f625f177f3a5d641a64e54d4b4540cb071070ecda060a8261fb6eb2ef",
+    "zh:a6818842b28d800f784e0c93284ff602b0c4022f407e4750da03f50b853a9a2c",
+    "zh:c4a1a2b52abd05687e6cfded4a789dcd7b43e7a746e4d02dd1055370cf9a994d",
+    "zh:cf65041bf12fc3bde709c1d267dbe94142bc05adcabc4feb17da3b12249132ac",
+    "zh:e385e00e7425dda9d30b74ab4ffa4636f4b8eb23918c0b763f0ffab84ece0c5c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version     = "2.2.0"
+  constraints = "~> 2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/infra/scoped/backend.tf
+++ b/infra/scoped/backend.tf
@@ -2,9 +2,10 @@ terraform {
   required_version = "= 0.14.2" # Pin to a specific version to avoid accidental upgrading of the statefile
 
   backend "s3" {
-    bucket = "identity-remote-state"
-    key    = "terraform.tfstate"
-    region = "eu-west-1"
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    bucket   = "identity-remote-state"
+    key      = "terraform.tfstate"
+    region   = "eu-west-1"
   }
 }
 

--- a/infra/scoped/backend.tf
+++ b/infra/scoped/backend.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "= 0.14.2" # Pin to a specific version to avoid accidental upgrading of the statefile
 
   backend "s3" {
-    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    role_arn = "arn:aws:iam::770700576653:role/identity-ci"
     bucket   = "identity-remote-state"
     key      = "terraform.tfstate"
     region   = "eu-west-1"

--- a/infra/scoped/provider.tf
+++ b/infra/scoped/provider.tf
@@ -1,10 +1,18 @@
 provider "aws" {
   region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+  }
 }
 
 provider "aws" {
   alias  = "aws_us-east-1"
   region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+  }
 }
 
 provider "aws" {

--- a/infra/scoped/provider.tf
+++ b/infra/scoped/provider.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "eu-west-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    role_arn = "arn:aws:iam::770700576653:role/identity-ci"
   }
 }
 
@@ -11,7 +11,7 @@ provider "aws" {
   region = "us-east-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    role_arn = "arn:aws:iam::770700576653:role/identity-ci"
   }
 }
 


### PR DESCRIPTION
This change uses `assume_role` to configure provider & backend with the correct permissions. 

Bringing this slightly more in-line with other `wellcomecollection` projects.

Also adds `.terraform.lock.hcl` to source control in line with recommendation: https://www.terraform.io/docs/language/dependency-lock.html