### PR TITLE
Add a couple of tests for 404 response branches

### DIFF
--- a/packages/shared/sierra-client/tests/sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/sierra-client.test.ts
@@ -319,6 +319,15 @@ describe('sierra client', () => {
 
     });
 
+    it('returns a 404 if there is no user', async () => {
+      moxios.stubRequest('/patrons/' + recordNumber, {
+        status: 404
+      });
+
+      const response = await client.updatePatronPostCreationFields(recordNumber, email);
+      equal(response.status, ResponseStatus.NotFound)
+    })
+
     it('returns an unexpected response code', async () => {
       moxios.stubRequest('/patrons/' + recordNumber, {
         status: 500
@@ -360,6 +369,15 @@ describe('sierra client', () => {
       equal(response.status, ResponseStatus.MalformedRequest)
 
     });
+
+    it('returns a 404 if there is no user', async () => {
+      moxios.stubRequest('/patrons/' + recordNumber, {
+        status: 404
+      });
+
+      const response = await client.updatePatronRecord(recordNumber, email);
+      equal(response.status, ResponseStatus.NotFound)
+    })
 
     it('returns an unexpected response code', async () => {
       moxios.stubRequest('/patrons/' + recordNumber, {


### PR DESCRIPTION
This is me kicking the tires on the tests – I looked in the Buildkite config to see how tests are run, and ran a couple locally.