### PR TITLE
Add a method for getting a list of holds for a patron from Sierra

### DIFF
--- a/packages/shared/sierra-client/src/holds.ts
+++ b/packages/shared/sierra-client/src/holds.ts
@@ -1,0 +1,25 @@
+export interface Location {
+  code: string;
+  name: string;
+}
+
+export interface Hold {
+  code: string;
+  name: string;
+}
+
+export interface Hold {
+  id: string;
+  patron: string;
+  frozen?: boolean;
+  placed: string;
+  pickupByDate: string;
+  location?: Location;
+  status?: HoldStatus;
+}
+
+export interface HoldResultSet {
+  total?: number;
+  start?: number;
+  entries: Hold[];
+}

--- a/packages/shared/sierra-client/src/holds.ts
+++ b/packages/shared/sierra-client/src/holds.ts
@@ -3,7 +3,7 @@ export interface Location {
   name: string;
 }
 
-export interface Hold {
+export interface HoldStatus {
   code: string;
   name: string;
 }

--- a/packages/shared/sierra-client/src/holds.ts
+++ b/packages/shared/sierra-client/src/holds.ts
@@ -10,7 +10,6 @@ export interface Hold {
 
 export interface Hold {
   id: string;
-  patron: string;
   frozen?: boolean;
   placed: string;
   pickupByDate: string;

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -2,6 +2,7 @@ import { APIResponse, errorResponse, ResponseStatus, successResponse, unhandledE
 import type { AxiosInstance } from 'axios';
 import axios from 'axios';
 import { extractRecordNumberFromLink, PatronRecord, toCreatePatron, toPatronRecord } from './patron';
+import { HoldResultSet } from './holds';
 
 export default class SierraClient {
 
@@ -218,6 +219,10 @@ export default class SierraClient {
         return unhandledError(error);
       });
     });
+  }
+
+  async getPatronHolds(recordNumber: number): Promise<APIResponse<HoldResultSet>> {
+    // boom
   }
 
   private async getInstance(): Promise<AxiosInstance> {

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -222,7 +222,19 @@ export default class SierraClient {
   }
 
   async getPatronHolds(recordNumber: number): Promise<APIResponse<HoldResultSet>> {
-    // boom
+    return this.getInstance().then(instance => {
+      return instance.get('/patrons/' + recordNumber + '/holds', {
+        params: {
+          fields: 'frozen,placed,pickupByDate,pickupLocation,status'
+        }
+      }).then(response => {
+        return successResponse(response.data);
+      }).catch(error => {
+        // Note: In testing, the Sierra API never returns a 404 here,
+        // even if asked to look up holds for a non-existent user.
+        return unhandledError(error);
+      });
+    });
   }
 
   private async getInstance(): Promise<AxiosInstance> {

--- a/packages/shared/sierra-client/tests/sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/sierra-client.test.ts
@@ -392,7 +392,7 @@ describe('sierra client', () => {
 
   describe('get list of holds', () => {
     it('returns an empty list of holds', async () => {
-      moxios.stubRequest('/patrons/' + recordNumber + '/holds', {
+      moxios.stubRequest('/patrons/' + recordNumber + '/holds?fields=frozen,placed,pickupByDate,pickupLocation,status', {
         status: 200,
         response: {
           entries: [],
@@ -407,22 +407,19 @@ describe('sierra client', () => {
       const result = (<SuccessResponse<HoldResultSet>>response).result;
       equal(result.total, 0);
       equal(result.start, 0);
-      equal(result.entries, []);
+      equal(result.entries.length, 0);
     })
 
     it('returns a list of holds', async () => {
-      moxios.stubRequest('/patrons/' + recordNumber + '/holds', {
+      moxios.stubRequest('/patrons/' + recordNumber + '/holds?fields=frozen,placed,pickupByDate,pickupLocation,status', {
         status: 200,
         response: {
           total: 2,
           entries: [
             {
-              id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/111111',
-              record: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/items/1234567',
-              patron: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/' + recordNumber,
+              id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/1111111',
               frozen: false,
               placed: '2001-01-01',
-              notWantedBeforeDate: '2019-11-19',
               pickupByDate: '2019-12-03T04:00:00Z',
               pickupLocation: {
                 code: 'sepbb',
@@ -431,17 +428,12 @@ describe('sierra client', () => {
               status: {
                 code: 'i',
                 name: 'item hold ready for pickup.'
-              },
-              recordType: 'i',
-              priority: 1
+              }
             },
             {
-              id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/222222',
-              record: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/items/7654321',
-              patron: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/' + recordNumber,
+              id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/2222222',
               frozen: false,
               placed: '2002-02-02',
-              notWantedBeforeDate: '2019-11-19',
               pickupByDate: '2019-12-03T04:00:00Z',
               pickupLocation: {
                 code: 'sepbb',
@@ -450,9 +442,7 @@ describe('sierra client', () => {
               status: {
                 code: 'i',
                 name: 'item hold ready for pickup.'
-              },
-              recordType: 'i',
-              priority: 1
+              }
             }
           ]
         }
@@ -462,11 +452,11 @@ describe('sierra client', () => {
       equal(response.status, ResponseStatus.Success)
 
       const result = (<SuccessResponse<HoldResultSet>>response).result;
-      equal(result.total, 0);
-      equal(result.start, 0);
+      equal(result.total, 2);
+      equal(result.start, undefined);
       equal(result.entries, [
         {
-          id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/111111',
+          id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/1111111',
           frozen: false,
           placed: '2001-01-01',
           pickupByDate: '2019-12-03T04:00:00Z',
@@ -497,7 +487,7 @@ describe('sierra client', () => {
     })
 
     it('returns an unexpected response code', async () => {
-      moxios.stubRequest('/patrons/' + recordNumber + '/holds', {
+      moxios.stubRequest('/patrons/' + recordNumber + '/holds?fields=frozen,placed,pickupByDate,pickupLocation,status', {
         status: 500,
       });
 

--- a/packages/shared/sierra-client/tests/sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/sierra-client.test.ts
@@ -3,6 +3,7 @@ import { equal } from 'assert';
 import axios, { AxiosInstance } from 'axios';
 import moxios from 'moxios';
 import SierraClient from '../lib';
+import { HoldResultSet } from '../lib/holds';
 import { PatronRecord } from '../lib/patron';
 
 describe('sierra client', () => {
@@ -390,6 +391,111 @@ describe('sierra client', () => {
   });
 
   describe('get list of holds', () => {
+    it('returns an empty list of holds', async () => {
+      moxios.stubRequest('/patrons/' + recordNumber + '/holds', {
+        status: 200,
+        response: {
+          entries: [],
+          start: 0,
+          total: 0
+        }
+      });
+
+      const response = await client.getPatronHolds(recordNumber);
+      equal(response.status, ResponseStatus.Success)
+
+      const result = (<SuccessResponse<HoldResultSet>>response).result;
+      equal(result.total, 0);
+      equal(result.start, 0);
+      equal(result.entries, []);
+    })
+
+    it('returns a list of holds', async () => {
+      moxios.stubRequest('/patrons/' + recordNumber + '/holds', {
+        status: 200,
+        response: {
+          total: 2,
+          entries: [
+            {
+              id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/111111',
+              record: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/items/1234567',
+              patron: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/' + recordNumber,
+              frozen: false,
+              placed: '2001-01-01',
+              notWantedBeforeDate: '2019-11-19',
+              pickupByDate: '2019-12-03T04:00:00Z',
+              pickupLocation: {
+                code: 'sepbb',
+                name: 'Rare Materials Room'
+              },
+              status: {
+                code: 'i',
+                name: 'item hold ready for pickup.'
+              },
+              recordType: 'i',
+              priority: 1
+            },
+            {
+              id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/222222',
+              record: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/items/7654321',
+              patron: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/' + recordNumber,
+              frozen: false,
+              placed: '2002-02-02',
+              notWantedBeforeDate: '2019-11-19',
+              pickupByDate: '2019-12-03T04:00:00Z',
+              pickupLocation: {
+                code: 'sepbb',
+                name: 'Rare Materials Room'
+              },
+              status: {
+                code: 'i',
+                name: 'item hold ready for pickup.'
+              },
+              recordType: 'i',
+              priority: 1
+            }
+          ]
+        }
+      });
+
+      const response = await client.getPatronHolds(recordNumber);
+      equal(response.status, ResponseStatus.Success)
+
+      const result = (<SuccessResponse<HoldResultSet>>response).result;
+      equal(result.total, 0);
+      equal(result.start, 0);
+      equal(result.entries, [
+        {
+          id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/111111',
+          frozen: false,
+          placed: '2001-01-01',
+          pickupByDate: '2019-12-03T04:00:00Z',
+          pickupLocation: {
+            code: 'sepbb',
+            name: 'Rare Materials Room'
+          },
+          status: {
+            code: 'i',
+            name: 'item hold ready for pickup.'
+          }
+        },
+        {
+          id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/2222222',
+          frozen: false,
+          placed: '2002-02-02',
+          pickupByDate: '2019-12-03T04:00:00Z',
+          pickupLocation: {
+            code: 'sepbb',
+            name: 'Rare Materials Room'
+          },
+          status: {
+            code: 'i',
+            name: 'item hold ready for pickup.'
+          }
+        }
+      ]);
+    })
+
     it('returns an unexpected response code', async () => {
       moxios.stubRequest('/patrons/' + recordNumber + '/holds', {
         status: 500,

--- a/packages/shared/sierra-client/tests/sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/sierra-client.test.ts
@@ -454,36 +454,8 @@ describe('sierra client', () => {
       const result = (<SuccessResponse<HoldResultSet>>response).result;
       equal(result.total, 2);
       equal(result.start, undefined);
-      equal(result.entries, [
-        {
-          id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/1111111',
-          frozen: false,
-          placed: '2001-01-01',
-          pickupByDate: '2019-12-03T04:00:00Z',
-          pickupLocation: {
-            code: 'sepbb',
-            name: 'Rare Materials Room'
-          },
-          status: {
-            code: 'i',
-            name: 'item hold ready for pickup.'
-          }
-        },
-        {
-          id: 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/2222222',
-          frozen: false,
-          placed: '2002-02-02',
-          pickupByDate: '2019-12-03T04:00:00Z',
-          pickupLocation: {
-            code: 'sepbb',
-            name: 'Rare Materials Room'
-          },
-          status: {
-            code: 'i',
-            name: 'item hold ready for pickup.'
-          }
-        }
-      ]);
+      equal(result.entries[0].id, 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/1111111');
+      equal(result.entries[1].id, 'https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/2222222');
     })
 
     it('returns an unexpected response code', async () => {

--- a/packages/shared/sierra-client/tests/sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/sierra-client.test.ts
@@ -388,6 +388,17 @@ describe('sierra client', () => {
       equal(response.status, ResponseStatus.UnknownError)
     });
   });
+
+  describe('get list of holds', () => {
+    it('returns an unexpected response code', async () => {
+      moxios.stubRequest('/patrons/' + recordNumber + '/holds', {
+        status: 500,
+      });
+
+      const response = await client.getPatronHolds(recordNumber);
+      equal(response.status, ResponseStatus.UnknownError)
+    })
+  })
 });
 
 const apiRoot: string = 'https://localhost';


### PR DESCRIPTION
The test responses are a mixture of experimenting today, and the stubs we have in the stacks-service repo.

These methods just exist in a shared library, and I haven't wired them up to endpoints yet – I assume we wouldn't expose the raw Sierra JSON to consumers. But it's the first step towards doing that, if we want to do so, and adding endpoints doesn't look too tricky (see #117).