### PR TITLE
Sets the default connection in the Auth0 tenant via Terraform

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
   rev: v1.45.0
   hooks:

--- a/infra/scoped/auth0-tenant.tf
+++ b/infra/scoped/auth0-tenant.tf
@@ -4,6 +4,9 @@ resource "auth0_tenant" "tenant" {
   support_email = local.email_support_address
   support_url   = aws_ssm_parameter.auth0_support_url.value
 
+  # This is required for the 'password' grant type that is used when testing user credentials
+  default_directory = auth0_connection.sierra.name
+
   flags {
     enable_custom_domain_in_emails = true
     universal_login                = true # Enables the 'new' Universal Login experience


### PR DESCRIPTION
This is required whenever the the `password` token exchange is utilised, so that Auth0 knows which connection the provided credentials are to be tested against. We use when a user provides their current credentials prior to a sensitive operation taking place.

Also fixes the `.pre-commit-config.yaml` to update to the new format.