### PR TITLE
Disabling trace logging for API Gateway

### DIFF
--- a/infra/scoped/api-stage.tf
+++ b/infra/scoped/api-stage.tf
@@ -40,7 +40,7 @@ resource "aws_api_gateway_method_settings" "identity_v1" {
   settings {
     metrics_enabled    = true
     logging_level      = "INFO"
-    data_trace_enabled = true
+    data_trace_enabled = false
   }
 
   depends_on = [


### PR DESCRIPTION
This PR disable the API Gateway's `v1` stage logging trace, preventing request bodies (and thus potentially sensitive data) from being logged in CloudWatch.