### PR TITLE
Fixing issue with Auth0 deployment pipeline

### DIFF
--- a/infra/scoped/auth0-tenant.tf
+++ b/infra/scoped/auth0-tenant.tf
@@ -19,9 +19,13 @@ resource "auth0_tenant" "tenant" {
     }
   }
 
-  # We use the "new" Universal Login Experience and so don't require either the 'change_password' or 'guardian_mfa_page'
-  # resources (which refer to the Legacy Experience), but if we don't have them and explicitly set them to 'false' then
-  # the 'a0deploy' utility (which our CI / CD pipeline uses) throws an error.
+  # The auth-deploy-cli tool queries the Auth0 Management API to fetch the current HTML customisations for the three
+  # pages supported by the Legacy Experience. It queries the API and gets JSON response, and then uses the names of the
+  # three pages (which are hardcoded in the tool) to look up the objects in the JSON. The code appears to assume that,
+  # if the key is present in the JSON, then the corresponding HTML must be there too inside the object. That isn't the
+  # case, and in fact if you've never toggled the customisations on / off, they appear as empty objects {}. The tool
+  # can't handle this and errors out.
+
   change_password {
     enabled = false
     html    = "unset"
@@ -33,7 +37,7 @@ resource "auth0_tenant" "tenant" {
   }
 
   error_page {
-    html          = ""
+    html          = "unset"
     show_log_link = false
     url           = local.ams_error_uri
   }

--- a/infra/scoped/auth0-tenant.tf
+++ b/infra/scoped/auth0-tenant.tf
@@ -19,6 +19,19 @@ resource "auth0_tenant" "tenant" {
     }
   }
 
+  # We use the "new" Universal Login Experience and so don't require either the 'change_password' or 'guardian_mfa_page'
+  # resources (which refer to the Legacy Experience), but if we don't have them and explicitly set them to 'false' then
+  # the 'a0deploy' utility (which our CI / CD pipeline uses) throws an error.
+  change_password {
+    enabled = false
+    html = ""
+  }
+
+  guardian_mfa_page {
+    enabled = false
+    html = ""
+  }
+
   error_page {
     html          = ""
     show_log_link = false

--- a/infra/scoped/auth0-tenant.tf
+++ b/infra/scoped/auth0-tenant.tf
@@ -24,12 +24,12 @@ resource "auth0_tenant" "tenant" {
   # the 'a0deploy' utility (which our CI / CD pipeline uses) throws an error.
   change_password {
     enabled = false
-    html = ""
+    html    = "unset"
   }
 
   guardian_mfa_page {
     enabled = false
-    html = ""
+    html    = "unset"
   }
 
   error_page {


### PR DESCRIPTION
As part of the Auth0 deployment, we depend on Auth0's [auth-deploy-cli](https://github.com/auth0/auth0-deploy-cli) tool. This queries the Auth0 API to fetch the current state of a tenant, then dumps that to files. We override / update those files during deployment, and they are then written back to Auth0.

The [auth-deploy-cli](https://github.com/auth0/auth0-deploy-cli) tool queries the Auth0 Management API [to fetch the current HTML customisations](https://github.com/auth0-extensions/auth0-source-control-extension-tools/blob/198e2febc123a133b05f89c6d681589c0926568c/src/auth0/handlers/pages.js#L102) for the three pages supported by the Legacy Experience. It queries the API and gets JSON response, and then uses [the names of the three pages (which are hardcoded in the tool) ](https://github.com/auth0-extensions/auth0-source-control-extension-tools/blob/198e2febc123a133b05f89c6d681589c0926568c/src/auth0/handlers/pages.js#L8) to look up the objects in the JSON. The code [appears to assume that](https://github.com/auth0-extensions/auth0-source-control-extension-tools/blob/198e2febc123a133b05f89c6d681589c0926568c/src/auth0/handlers/pages.js#L106), if the key is present in the JSON, then the corresponding HTML must be there too inside the object. That isn't the case, and in fact if you've never toggled the customisations on / off, they appear as empty objects {}. The tool can't handle this and errors out, resulting in

```
2021-05-06T13:03:00.205Z - debug: TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
```

This PR ensures there are always (dummy) values available.