### PR TITLE
Standardise terraform backend & provider roles

### DIFF
--- a/.buildkite/scripts/init-environment.sh
+++ b/.buildkite/scripts/init-environment.sh
@@ -10,7 +10,7 @@ TF_BACKEND_ROLE_ARN="arn:aws:iam::770700576653:role/identity-ci"
 
 function __process_environment_variables() {
   export AWS_DEFAULT_REGION=eu-west-1
-  export TF_VAR_provider_role=identity-ci
+  export TF_VAR_provider_role_arn=${TF_BACKEND_ROLE_ARN}
   export NORMALIZED_BRANCH_NAME="${BUILDKITE_BRANCH/\//-}"
 }
 

--- a/.buildkite/scripts/init-environment.sh
+++ b/.buildkite/scripts/init-environment.sh
@@ -6,8 +6,11 @@
 
 set -o errexit
 
+TF_BACKEND_ROLE_ARN="arn:aws:iam::770700576653:role/identity-ci"
+
 function __process_environment_variables() {
   export AWS_DEFAULT_REGION=eu-west-1
+  export TF_VAR_provider_role=identity-ci
   export NORMALIZED_BRANCH_NAME="${BUILDKITE_BRANCH/\//-}"
 }
 
@@ -27,7 +30,9 @@ function __process_buildkite_metadata() {
 
 # shellcheck disable=SC1091
 function __init_terraform_env_vars() {
-  cd /app/infra/scoped && terraform init && terraform workspace select "${DEPLOY_ENVIRONMENT}"
+  cd /app/infra/scoped && \
+    terraform init -backend-config="role_arn=${TF_BACKEND_ROLE_ARN}" && \
+    terraform workspace select "${DEPLOY_ENVIRONMENT}"
   mkdir -p /app/.buildkite/build
   terraform output -json -no-color | jq -r .ci_environment_variables.value[] >/app/.buildkite/build/env.sh
   chmod +x /app/.buildkite/build/env.sh && source /app/.buildkite/build/env.sh && rm /app/.buildkite/build/env.sh

--- a/infra/scoped/.terraform.lock.hcl
+++ b/infra/scoped/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/alexkappa/auth0" {
   constraints = "~> 0.16.0"
   hashes = [
     "h1:+H+a5vOljY9pzqsl/XQ2tdhhztoEyBMdupl3JDb8tp0=",
+    "h1:Yuan3uU/eISWfu9f7JMG8WackUOMnrrh3LFywdxqMek=",
     "zh:173017f420275c617881602a35fda7beb6e097d6d32fbdbb035046b4a90a4136",
     "zh:2422e7e41fea5e9578e9fd5c71376ab48328141b90ffd7e2c0823d581b309563",
     "zh:433c7cac260c7882d4f889d097907ea779fb7d890366109ca9c3d18ad056aac9",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = "~> 2.0.0"
   hashes = [
     "h1:WWGcM4hCkZLObytvhPHxR/s6FR7+jhNHGQ+2DYvBKbI=",
+    "h1:eOUi4EO4QTgPuz+gmD8xy2LTTxNfyc9txyc9PDARth8=",
     "zh:1c3300a6686481ed0b3ce456949805b5c55f901b77108543046f12118a102914",
     "zh:2d44bcc8a5ea3f2c2ff54ca4c4b273cdc3500ad8bb6929eec6722bb9d10a9714",
     "zh:4be17c4e06a74ca30a3c9e88446e453ad16c493b2ddef872a6580dbfe618a1b4",
@@ -42,6 +44,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.14.1"
   constraints = "~> 3.14.0"
   hashes = [
+    "h1:ADr5q/0e+ZLDWLRYA6jzbawTKInpnuJFafhUlM4PlQ8=",
     "h1:RgWlWcvBvFa0Vfs2s7dzvhZl6U9nH1jaK26L4iHUKGs=",
     "zh:12668d9cb947dbebefe4af454180021ae28510d875b77747a95d5f77a822120f",
     "zh:2c6e383e722d5ef955ee3c8d50eae8cadd92d4d6b8900250333f683f69bb498c",
@@ -60,6 +63,7 @@ provider "registry.terraform.io/hashicorp/external" {
   version     = "2.0.0"
   constraints = "~> 2.0.0"
   hashes = [
+    "h1:6S7hqjmUnoAZ5D/0F1VlJZKSJsUIBh7Ro0tLjGpKO0g=",
     "h1:Q5xqryWI3tCY8yr+fugq7dz4Qz+8g4GaW9ZS8dc6Ob8=",
     "zh:07949780dd6a1d43e7b46950f6e6976581d9724102cb5388d3411a1b6f476bde",
     "zh:0a4f4636ff93f0644affa8474465dd8c9252946437ad025b28fc9f6603534a24",
@@ -78,6 +82,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.0.1"
   constraints = "~> 3.0.0"
   hashes = [
+    "h1:0QaSbRBgBi8vI/8IRwec1INdOqBxXbgsSFElx1O4k4g=",
     "h1:SzM8nt2wzLMI28A3CWAtW25g3ZCm1O4xD0h3Ps/rU1U=",
     "zh:0d4f683868324af056a9eb2b06306feef7c202c88dbbe6a4ad7517146a22fb50",
     "zh:4824b3c7914b77d41dfe90f6f333c7ac9860afb83e2a344d91fbe46e5dfbec26",
@@ -96,6 +101,7 @@ provider "registry.terraform.io/hashicorp/template" {
   version     = "2.2.0"
   constraints = "~> 2.2.0"
   hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
     "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",

--- a/infra/scoped/backend.tf
+++ b/infra/scoped/backend.tf
@@ -2,9 +2,12 @@ terraform {
   required_version = "= 0.14.2" # Pin to a specific version to avoid accidental upgrading of the statefile
 
   backend "s3" {
-    bucket = "identity-remote-state"
-    key    = "terraform.tfstate"
-    region = "eu-west-1"
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+
+    bucket         = "identity-remote-state"
+    key            = "terraform.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
   }
 }
 

--- a/infra/scoped/provider.tf
+++ b/infra/scoped/provider.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "eu-west-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::770700576653:role/${var.provider_role}"
+    role_arn = var.provider_role_arn
   }
 
   # Ignore deployment tags on services
@@ -16,7 +16,7 @@ provider "aws" {
   region = "us-east-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::770700576653:role/${var.provider_role}"
+    role_arn = var.provider_role_arn
   }
 }
 

--- a/infra/scoped/provider.tf
+++ b/infra/scoped/provider.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "eu-west-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    role_arn = "arn:aws:iam::770700576653:role/${var.provider_role}"
   }
 
   # Ignore deployment tags on services
@@ -16,7 +16,7 @@ provider "aws" {
   region = "us-east-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    role_arn = "arn:aws:iam::770700576653:role/${var.provider_role}"
   }
 }
 

--- a/infra/scoped/provider.tf
+++ b/infra/scoped/provider.tf
@@ -1,10 +1,23 @@
 provider "aws" {
   region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+  }
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
+  }
 }
 
 provider "aws" {
   alias  = "aws_us-east-1"
   region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+  }
 }
 
 provider "aws" {
@@ -14,7 +27,6 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
-  profile = "wellcome"
 }
 
 provider "aws" {
@@ -24,5 +36,4 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
   }
-  profile = "wellcome"
 }

--- a/infra/scoped/variables.tf
+++ b/infra/scoped/variables.tf
@@ -1,3 +1,10 @@
+# Provider config
+
+variable "provider_role" {
+  type    = string
+  default = "identity-developer"
+}
+
 # Tags
 
 variable "tag_project" {

--- a/infra/scoped/variables.tf
+++ b/infra/scoped/variables.tf
@@ -1,8 +1,8 @@
 # Provider config
 
-variable "provider_role" {
+variable "provider_role_arn" {
   type    = string
-  default = "identity-developer"
+  default = "arn:aws:iam::770700576653:role/identity-developer"
 }
 
 # Tags

--- a/infra/static/backend.tf
+++ b/infra/static/backend.tf
@@ -2,8 +2,11 @@ terraform {
   required_version = "= 0.14.2" # Pin to a specific version to avoid accidental upgrading of the statefile
 
   backend "s3" {
-    bucket = "identity-static-remote-state"
-    key    = "terraform.tfstate"
-    region = "eu-west-1"
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+
+    bucket         = "identity-static-remote-state"
+    key            = "terraform.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
   }
 }

--- a/infra/static/provider.tf
+++ b/infra/static/provider.tf
@@ -9,4 +9,8 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+  }
 }


### PR DESCRIPTION
This brings the terraform backend and provider config into line with other Wellcome Collection repos: it refers to roles explicitly by ARN rather than using local profiles, and pushes environment config/overrides into CI. It also enables state locking for the S3 backend. Developers will still need to provide environment variables to the Auth0 provider.