### PR TITLE
Add terraform runner script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,6 @@ repos:
       exclude: ^infra/scoped/task-definitions
     - id: check-yaml
 
-- repo: https://github.com/detailyang/pre-commit-shell.git
-  rev: v1.0.6
-  hooks:
-    - id: shell-lint
-      args: [--format=json]
-
 - repo: https://github.com/bemeurer/beautysh.git
   rev: 6.0.1
   hooks:

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -107,6 +107,7 @@ resource "auth0_client_grant" "buildkite" {
     "update:connections",
     "delete:connections",
     "create:connections",
+    "read:custom_domains",
     "read:resource_servers",
     "update:resource_servers",
     "delete:resource_servers",

--- a/infra/scoped/backend.tf
+++ b/infra/scoped/backend.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = "= 0.14.2" # Pin to a specific version to avoid accidental upgrading of the statefile
-
   backend "s3" {
     role_arn = "arn:aws:iam::770700576653:role/identity-developer"
 

--- a/infra/scoped/run_terraform.sh
+++ b/infra/scoped/run_terraform.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+TERRAFORM_WORKSPACE=$(terraform workspace show)
+
+AWS_CLI_PROFILE="identity-terraform"
+IDENTITY_DEVELOPER_ARN="arn:aws:iam::770700576653:role/identity-developer"
+
+AUTH0_DOMAIN_SSM="identity-auth0_domain-$TERRAFORM_WORKSPACE"
+CLIENT_ID_SSM="/identity/$TERRAFORM_WORKSPACE/buildkite/auth0_client_id"
+CLIENT_SECRET_SM="identity/$TERRAFORM_WORKSPACE/buildkite/auth0_client_secret"
+
+# Starting caller-identity
+#aws sts get-caller-identity
+
+aws configure set region eu-west-1 --profile $AWS_CLI_PROFILE
+aws configure set role_arn $IDENTITY_DEVELOPER_ARN --profile $AWS_CLI_PROFILE
+aws configure set source_profile default --profile $AWS_CLI_PROFILE
+
+# Assumed caller-identity
+#aws sts get-caller-identity --profile identity-terraform
+
+AUTH0_DOMAIN=$(aws ssm get-parameter --name "$AUTH0_DOMAIN_SSM" --profile "$AWS_CLI_PROFILE" --output text --query 'Parameter.Value')
+AUTH0_CLIENT_ID=$(aws ssm get-parameter --name "$CLIENT_ID_SSM" --profile "$AWS_CLI_PROFILE" --output text --query 'Parameter.Value')
+AUTH0_CLIENT_SECRET=$(aws secretsmanager get-secret-value --secret-id "$CLIENT_SECRET_SM" --profile "$AWS_CLI_PROFILE" --output text --query 'SecretString')
+
+AUTH0_DOMAIN=$AUTH0_DOMAIN \
+  AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID \
+  AUTH0_CLIENT_SECRET=$AUTH0_CLIENT_SECRET \
+  terraform "$@"


### PR DESCRIPTION
In order to run terraform without having to copy paste credentials from Auth0, this change pulls the buildkite credentials from secrets manager and applies those to the running environment.

This allows terraform to be run in CI or locally and simplifies the process of running terraform. Using this change removes the need to have a client for each user and to maintain that either in or out of terraform. 

This change does remove one part of the audit trail to see who (i.e. which client) has made changes in Auth0, but at present that is of dubious value.

**Note:** The values required to be set in SM/SSM have been manually set for _stage_ only currently, they will need to be added for _prod_ before merging. We could set those values from (buildkite client id/secret) if there is appetite to do so.