### PR TITLE
Add tests for invalid resource in api-authorizer

### DIFF
--- a/packages/apps/api-authorizer/tests/api-authorizer.test.ts
+++ b/packages/apps/api-authorizer/tests/api-authorizer.test.ts
@@ -133,6 +133,36 @@ describe('API Authorizer', () => {
     );
   });
 
+  it('denies requests where the user is accessing an invalid resource', async () => {
+    const userId = 'test_id';
+    const event = createEvent({
+      token: 'test token',
+      resource: '/users/{userId}/ice_cream',
+      method: 'GET',
+      userId,
+    });
+
+    await withAuth0Response(
+      {
+        status: ResponseStatus.Success,
+        result: {
+          userId,
+          name: 'test name',
+          firstName: 'test',
+          lastName: 'name',
+          email: 'test@example.com',
+        },
+      },
+      async () => {
+        const result = await lambdaHandler(event);
+        expect(result).toHaveProperty(
+          'policyDocument.Statement.0.Effect',
+          'Deny'
+        );
+      }
+    );
+  });
+
   it('uses cached user info when available', async () => {
     mockRedis.get.mockResolvedValue(
       JSON.stringify({


### PR DESCRIPTION
This change adds a test to cover the case where an invalid resource is requested, in order to provide a better picture of application behaviour.

Trying to discern why https://github.com/wellcomecollection/identity/pull/151 is not working I wanted to see this behaviour, so added a test to cover it.