### PR TITLE
Return a more informative error from the login scripts

### DIFF
--- a/packages/apps/auth0-actions/src/databaseScriptGlobals.d.ts
+++ b/packages/apps/auth0-actions/src/databaseScriptGlobals.d.ts
@@ -1,6 +1,8 @@
 export {};
 
 declare global {
+  // Some custom errors are available:
+  // https://auth0.com/docs/connections/database/custom-db/error-handling#types-of-errors
   class WrongUsernameOrPasswordError extends Error {
     constructor(emailOrId?: string, message?: string);
   }

--- a/packages/apps/auth0-actions/src/databaseScriptGlobals.d.ts
+++ b/packages/apps/auth0-actions/src/databaseScriptGlobals.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  class WrongUsernameOrPasswordError extends Error {
+    constructor(emailOrId?: string, message?: string);
+  }
+}

--- a/packages/apps/auth0-actions/src/get_user.ts
+++ b/packages/apps/auth0-actions/src/get_user.ts
@@ -24,7 +24,7 @@ export async function getUser(email: string) {
   } else if (patronRecordResponse.status === ResponseStatus.NotFound) {
     return undefined;
   } else {
-    throw patronRecordResponse;
+    throw new Error(patronRecordResponse.message);
   }
 }
 

--- a/packages/apps/auth0-actions/src/login.ts
+++ b/packages/apps/auth0-actions/src/login.ts
@@ -9,6 +9,9 @@ declare const configuration: {
   CLIENT_SECRET: string;
 };
 
+const invalidCredentialsMessage =
+  "We don't recognise the email and/or password you entered. Please check your entry and try again";
+
 async function login(email: string, password: string) {
   const apiRoot = configuration.API_ROOT;
   const clientKey = configuration.CLIENT_KEY;
@@ -18,7 +21,7 @@ async function login(email: string, password: string) {
 
   const patronRecordResponse = await sierraClient.getPatronRecordByEmail(email);
   if (patronRecordResponse.status === ResponseStatus.NotFound) {
-    throw new WrongUsernameOrPasswordError(email);
+    throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
   }
   if (patronRecordResponse.status !== ResponseStatus.Success) {
     throw new Error(patronRecordResponse.message);
@@ -30,7 +33,7 @@ async function login(email: string, password: string) {
     password
   );
   if (validationResponse.status !== ResponseStatus.Success) {
-    throw new WrongUsernameOrPasswordError(email);
+    throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
   }
 
   return patronRecordToUser(patronRecord);

--- a/packages/apps/auth0-actions/src/login.ts
+++ b/packages/apps/auth0-actions/src/login.ts
@@ -10,7 +10,7 @@ declare const configuration: {
 };
 
 const invalidCredentialsMessage =
-  "We don't recognise the email and/or password you entered. Please check your entry and try again";
+  "We don't recognise the email and/or password you entered. Please check your entry and try again.";
 
 async function login(email: string, password: string) {
   const apiRoot = configuration.API_ROOT;


### PR DESCRIPTION
Auth0 gives us some error classes to communicate different error causes - this gives us control over the microcopy, and fixes the bug that incorrect credentials on a first login returned a "something went wrong" error.

The copy used here is OK for now - see [Slack discussion](https://wellcome.slack.com/archives/C294K7D5M/p1625133599118500)