### PR TITLE
Add APM config to requests API ECS service

### DIFF
--- a/infra/scoped/ecs_services.tf
+++ b/infra/scoped/ecs_services.tf
@@ -7,6 +7,11 @@ locals {
   routable_private_subnets = slice(local.private_subnets, 0, local.clamped_n_subnets)
 
   es_secrets = data.terraform_remote_state.catalogue_api_shared.outputs["es_requests_secret_config"]
+
+  apm_secret_config = {
+    apm_server_url = "identity/api/apm_server_url"
+    apm_secret     = "identity/api/apm_secret"
+  }
 }
 
 module "requests" {
@@ -28,8 +33,10 @@ module "requests" {
     metrics_namespace = "requests"
     app_base_url      = local.identity_v1_endpoint
     sierra_base_url   = "https://libsys.wellcomelibrary.org/iii/sierra-api"
+    apm_service_name  = "requests-api"
+    apm_environment   = terraform.workspace
   }
-  secrets = merge(local.es_secrets, {
+  secrets = merge(local.es_secrets, local.apm_secret_config, {
     sierra_api_key    = "sierra-api-credentials-${terraform.workspace}:SierraAPIKey"
     sierra_api_secret = "sierra-api-credentials-${terraform.workspace}:SierraAPISecret"
   })


### PR DESCRIPTION
Requests does not have APM Tracing unlike Items & Search - it should, this adds it.

This change adds the config to the ECS service, this should go out before: https://github.com/wellcomecollection/catalogue-api/pull/204

Note: this is applied (targeted to requests module).