### PR TITLE
Remove input field deployments

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -1,25 +1,7 @@
 steps:
 
-    # Only prompt for deployment parameters if the build was triggered via the Web UI. All other
-    # methods of invoking the build should provide these are environment variables to the build.
-  - block: "provide deployment parameters"
-    prompt: "Provide deployment parameters"
-    if: build.source == "ui"
-    fields:
-      - text: "Deployment Environment"
-        hint: "The environment to deploy to, e.g. 'stage' or 'prod'"
-        required: true
-        key: "deploy-environment"
-      - text: "Deployment API Gateway Stage"
-        hint: "The API Gateway stage to deploy to, e.g. 'v1' or 'v2'"
-        required: true
-        key: "deploy-api-gateway-stage"
-
-    # Deploy the Auth0 scripts to Auth0. We don't want to execute the deployment every time there's
-    # a push to revision control. We're only interested in doing a deployment if e.g. it was
-    # manually invoked via the web UI, or a downstream job triggered the build.
+  # Deploy any changes to Auth0 scripts
   - name: "auth0 deployment"
-    if: build.source != "webhook"
     command:
       - ". /app/.buildkite/scripts/init-environment.sh"
       - "/app/.buildkite/scripts/auth0-deployment.sh"
@@ -40,11 +22,8 @@ steps:
             - AWS_SESSION_TOKEN
             - DEPLOY_ENVIRONMENT
 
-  # Deploy the Lambda Function code to Lambda. We don't want to execute the deployment every time there's
-  # a push to revision control. We're only interested in doing a deployment if e.g. it was
-  # manually invoked via the web UI, or a downstream job triggered the build.
-  - name: "lambda function deployment"
-    if: build.source != "webhook"
+  # Deploy Lambdas to AWS
+  - name: "lambda deployment"
     command:
       - ". /app/.buildkite/scripts/init-environment.sh"
       - "/app/.buildkite/scripts/aws-lambda-deployment.sh"

--- a/.buildkite/scripts/init-environment.sh
+++ b/.buildkite/scripts/init-environment.sh
@@ -14,20 +14,6 @@ function __process_environment_variables() {
   export NORMALIZED_BRANCH_NAME="${BUILDKITE_BRANCH/\//-}"
 }
 
-function __process_buildkite_metadata() {
-  # Need to revisit this - not sure we should be defaulting to 'stage' and 'v1'?
-  if [ "${BUILDKITE_SOURCE}" == "ui" ]; then
-    DEPLOY_ENVIRONMENT=$(buildkite-agent meta-data get deploy-environment)
-    DEPLOY_API_GATEWAY_STAGE=$(buildkite-agent meta-data get deploy-api-gateway-stage)
-  else
-    DEPLOY_ENVIRONMENT=stage
-    DEPLOY_API_GATEWAY_STAGE=v1
-  fi
-
-  export DEPLOY_ENVIRONMENT
-  export DEPLOY_API_GATEWAY_STAGE
-}
-
 # shellcheck disable=SC1091
 function __init_terraform_env_vars() {
   cd /app/infra/scoped && \
@@ -39,5 +25,4 @@ function __init_terraform_env_vars() {
 }
 
 __process_environment_variables
-__process_buildkite_metadata
 __init_terraform_env_vars

--- a/.buildkite/scripts/init-environment.sh
+++ b/.buildkite/scripts/init-environment.sh
@@ -12,6 +12,8 @@ function __process_environment_variables() {
   export AWS_DEFAULT_REGION=eu-west-1
   export TF_VAR_provider_role_arn=${TF_BACKEND_ROLE_ARN}
   export NORMALIZED_BRANCH_NAME="${BUILDKITE_BRANCH/\//-}"
+  export DEPLOY_ENVIRONMENT=${DEPLOY_ENVIRONMENT:=stage}
+  export DEPLOY_API_GATEWAY_STAGE=${DEPLOY_API_GATEWAY_STAGE:=v1}
 }
 
 # shellcheck disable=SC1091


### PR DESCRIPTION
Previously the mechanism to deploy to prod required entering details into a manual input step, when we moved to separate stage/prod deployment steps that gate was not removed resulting in all deployments going to stage due to incorrectly set defaults.

This change removes the last bits of the "manual input step" and ignores webhook/ui deployment types (the deployment step is always triggered from another pipeline, never webhook or UI).

This change will hopefully fix the failing smoke tests in prod caused by latest changes not being deployed.