### PR TITLE
Add the user hold limit to the requests service

### DIFF
--- a/infra/scoped/ecs_services.tf
+++ b/infra/scoped/ecs_services.tf
@@ -35,6 +35,7 @@ module "requests" {
     sierra_base_url   = "https://libsys.wellcomelibrary.org/iii/sierra-api"
     apm_service_name  = "requests-api"
     apm_environment   = terraform.workspace
+    user_hold_limit   = local.per_user_hold_limit
   }
   secrets = merge(local.es_secrets, local.apm_secret_config, {
     sierra_api_key    = "sierra-api-credentials-${terraform.workspace}:SierraAPIKey"

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -81,4 +81,15 @@ locals {
 
   requests_lb_port    = 8000
   requests_repository = data.terraform_remote_state.catalogue_api_shared.outputs["ecr_requests_repository_url"]
+
+  # This should be the max number of items that a user can order in Sierra.
+  #
+  # Although Sierra enforces the canonical limit, it's useful for the
+  # requesting API to know what the limit should be -- it means we can
+  # return a more helpful error message when a request fails because
+  # somebody is at their hold limit.
+  #
+  # The hold limit was increased to 15 on 6 August 2021.
+  # See https://wellcome.slack.com/archives/CUA669WHH/p1628089731008800
+  per_user_hold_limit = 15
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5255

This exposes the environment variable to the app – I'll do a separate patch to actually use the variable.