### PR TITLE
Add Slack alarms for 5XX errors from API Gateway

### DIFF
--- a/infra/scoped/api-gateway.tf
+++ b/infra/scoped/api-gateway.tf
@@ -6,6 +6,23 @@ resource "aws_api_gateway_rest_api" "identity" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "alarm_5xx" {
+  alarm_name          = "identity-api-${terraform.workspace}-5xx-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "5XXError"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+
+  dimensions = {
+    ApiName = aws_api_gateway_rest_api.identity.name
+  }
+
+  alarm_actions = [local.api_gateway_alerts_topic_arn]
+}
+
 # /users
 
 resource "aws_api_gateway_resource" "users" {

--- a/infra/scoped/ecs_services.tf
+++ b/infra/scoped/ecs_services.tf
@@ -35,6 +35,7 @@ module "requests" {
     sierra_base_url   = "https://libsys.wellcomelibrary.org/iii/sierra-api"
     apm_service_name  = "requests-api"
     apm_environment   = terraform.workspace
+    user_hold_limit   = local.per_user_hold_limit
   }
   secrets = merge(local.es_secrets, local.apm_secret_config, {
     sierra_api_key    = "sierra-api-credentials-${terraform.workspace}:SierraAPIKey"

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -82,6 +82,10 @@ locals {
   requests_lb_port    = 8000
   requests_repository = data.terraform_remote_state.catalogue_api_shared.outputs["ecr_requests_repository_url"]
 
+  monitoring_outputs = data.terraform_remote_state.monitoring.outputs
+
+  api_gateway_alerts_topic_arn = local.monitoring_outputs["identity_api_gateway_alerts_topic_arn"]
+
   # This should be the max number of items that a user can order in Sierra.
   #
   # Although Sierra enforces the canonical limit, it's useful for the

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -81,4 +81,15 @@ locals {
 
   requests_lb_port    = 8000
   requests_repository = data.terraform_remote_state.catalogue_api_shared.outputs["ecr_requests_repository_url"]
+
+  # This should be the max number of items that a user can order in Sierra.
+  #
+  # Although Sierra enforces the canonical limit, it's useful for the
+  # requesting API to know what the limit should be -- it means we can
+  # return a more helpful error message when a request fails because
+  # somebody is at their hold limit.
+  #
+  # The hold limit was increased to 15 on 6 August 2021.
+  # See https://wellcome.slack.com/archives/CUA669WHH/p1628089731008800
+  per_user_hold_limit = 15
 }

--- a/infra/scoped/terraform.tf
+++ b/infra/scoped/terraform.tf
@@ -65,3 +65,14 @@ data "terraform_remote_state" "accounts_identity" {
     region = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/monitoring.tfstate"
+    region   = "eu-west-1"
+  }
+}


### PR DESCRIPTION
This means we'll get alerts of API Gateway errors for the identity APIs, which we haven't had before.

Note that I've had to cherry-pick https://github.com/wellcomecollection/identity/pull/168 back in, I'm not sure what happened to it. 🤷‍♀️ 

Requires wellcomecollection/platform-infrastructure#232, part of wellcomecollection/platform#5245