### PR TITLE
Remove identity-admin leftovers

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -180,39 +180,6 @@ resource "auth0_client" "account_management_system" {
   }
 }
 
-# Account Administration System
-# Lets the Account Administration System component initialise and process OAuth 2.0 / OIDC login requests through Auth0
-
-resource "auth0_client" "account_admin_system" {
-  name                 = "Account Administration System${local.environment_qualifier}"
-  app_type             = "regular_web"
-  is_first_party       = true
-  custom_login_page_on = true
-
-  grant_types = [
-    "authorization_code"
-  ]
-
-  callbacks = [
-    local.aas_redirect_uri
-  ]
-
-  allowed_logout_urls = [
-    local.aas_logout_uri
-  ]
-
-  jwt_configuration {
-    alg = "RS256"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      custom_login_page_preview,
-      custom_login_page
-    ]
-  }
-}
-
 # Smoke Test Client
 # For automated smoke testing after deployment
 

--- a/infra/scoped/auth0-connection.tf
+++ b/infra/scoped/auth0-connection.tf
@@ -55,38 +55,3 @@ resource "auth0_connection" "sierra" {
     ]
   }
 }
-
-resource "auth0_connection" "azure_ad" {
-
-  name     = "AzureAD-Connection"
-  strategy = "oauth2"
-
-  enabled_clients = concat([
-    auth0_client.account_admin_system.id],
-    terraform.workspace != "prod" ? local.stage_test_client_ids : []
-  )
-
-  options {
-    authorization_endpoint = "https://login.microsoftonline.com/${aws_ssm_parameter.azure_ad_directory_id.value}/oauth2/v2.0/authorize"
-    token_endpoint         = "https://login.microsoftonline.com/${aws_ssm_parameter.azure_ad_directory_id.value}/oauth2/v2.0/token"
-
-    client_id     = aws_ssm_parameter.azure_ad_application_id.value
-    client_secret = data.aws_secretsmanager_secret_version.azure_ad_client_secret_version.secret_string
-
-    scopes = [
-      "User.Read"
-    ]
-
-    scripts = {
-      // This creates an empty function on the first apply, as it will be managed by
-      // the deployment scripts and ignored by TF (see lifecycle block)
-      fetchUserProfile = file("${path.module}/data/empty.js")
-    }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      options["scripts"]
-    ]
-  }
-}

--- a/infra/scoped/parameters.tf
+++ b/infra/scoped/parameters.tf
@@ -370,16 +370,6 @@ resource "aws_ssm_parameter" "account_admin_system-auth0_domain" {
   }
 }
 
-resource "aws_ssm_parameter" "account_admin_system-auth0_client_id" {
-  name  = "/identity/${terraform.workspace}/account_admin_system/auth0_client_id"
-  type  = "String"
-  value = auth0_client.account_admin_system.id
-
-  tags = {
-    "Name" = "/identity/${terraform.workspace}/account_admin_system/auth0_client_id"
-  }
-}
-
 resource "aws_ssm_parameter" "account_admin_system-auth0_callback_url" {
   name  = "/identity/${terraform.workspace}/account_admin_system/auth0_callback_url"
   type  = "String"

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -103,11 +103,6 @@ resource "aws_secretsmanager_secret" "account_admin_system-auth0_client_secret" 
   }
 }
 
-resource "aws_secretsmanager_secret_version" "account_admin_system-auth0_client_secret" {
-  secret_id     = aws_secretsmanager_secret.account_admin_system-auth0_client_secret.id
-  secret_string = auth0_client.account_admin_system.client_secret
-}
-
 resource "aws_secretsmanager_secret" "account_admin_system-api_key" {
   name = "identity/${terraform.workspace}/account_admin_system/api_key"
 


### PR DESCRIPTION
Removes the Auth0 client for the account admin system and the Azure connector, which it required.