### PR TITLE
Add OpenAthens SAML IDP client to Auth0

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -180,6 +180,32 @@ resource "auth0_client" "account_management_system" {
   }
 }
 
+# OpenAthens SAML Identity Provider
+# Allows OpenAthens to authenticate users against the Auth0 user-pool
+
+resource "auth0_client" "openathens_saml_idp" {
+  name           = "OpenAthens SAML IDP${local.environment_qualifier}"
+  app_type       = "regular_web"
+  is_first_party = true
+
+  addons {
+    samlp {
+      mappings = {
+        user_id     = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
+        email       = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+        name        = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+        given_name  = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"
+        family_name = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"
+        upn         = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"
+        groups      = "http://schemas.xmlsoap.org/claims/Group"
+      }
+      name_identifier_probes = [
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+      ]
+    }
+  }
+}
+
 # Smoke Test Client
 # For automated smoke testing after deployment
 

--- a/infra/scoped/auth0-connection.tf
+++ b/infra/scoped/auth0-connection.tf
@@ -5,6 +5,7 @@ resource "auth0_connection" "sierra" {
   enabled_clients = concat([
     auth0_client.api_gateway_identity.id, # Required to allow the Lambda API client credentials to operate on the connection
     auth0_client.account_management_system.id,
+    auth0_client.openathens_saml_idp.id,
     auth0_client.smoke_test.id],
     terraform.workspace != "prod" ? local.stage_test_client_ids : [],
   )

--- a/infra/scoped/output.tf
+++ b/infra/scoped/output.tf
@@ -34,6 +34,11 @@ output "auth0_client_dummy_client_secret" {
   value     = auth0_client.dummy_test.*.client_secret
   sensitive = true
 }
+
+output "auth0_openathens_saml_idp_client_id" {
+  value = auth0_client.openathens_saml_idp.client_id
+}
+
 # Email
 
 output "ses_smtp_username" {


### PR DESCRIPTION
This change configures an OpenAthens SAML IDP in Auth0.

For https://github.com/wellcomecollection/platform/issues/5120