### PR TITLE
Update secrets handling to be clearer

### DIFF
--- a/infra/scoped/auth0-connection.tf
+++ b/infra/scoped/auth0-connection.tf
@@ -45,8 +45,8 @@ resource "auth0_connection" "sierra" {
 
     configuration = {
       API_ROOT      = aws_ssm_parameter.sierra_api_hostname.value,
-      CLIENT_KEY    = data.external.sierra_api_credentials.result.SierraAPIKey,
-      CLIENT_SECRET = data.external.sierra_api_credentials.result.SierraAPISecret
+      CLIENT_KEY    = local.sierra_api_credentials.client_key,
+      CLIENT_SECRET = local.sierra_api_credentials.client_secret
     }
   }
 

--- a/infra/scoped/lambda.tf
+++ b/infra/scoped/lambda.tf
@@ -89,8 +89,8 @@ resource "aws_lambda_function" "api" {
   environment {
     variables = {
       SIERRA_API_ROOT      = aws_ssm_parameter.sierra_api_hostname.value,
-      SIERRA_CLIENT_KEY    = data.external.sierra_api_credentials.result.SierraAPIKey
-      SIERRA_CLIENT_SECRET = data.external.sierra_api_credentials.result.SierraAPISecret
+      SIERRA_CLIENT_KEY    = local.sierra_api_credentials.client_key
+      SIERRA_CLIENT_SECRET = local.sierra_api_credentials.client_secret,
       AUTH0_API_ROOT       = local.auth0_endpoint
       AUTH0_API_AUDIENCE   = auth0_client_grant.api_gateway_identity.audience,
       AUTH0_CLIENT_ID      = auth0_client.api_gateway_identity.client_id,

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -1,123 +1,46 @@
-# Sierra API
-
+# Sierra credentials
+# These are set manually (we can't provision Sierra in TF)
 resource "aws_secretsmanager_secret" "sierra_api_credentials" {
   name = "sierra-api-credentials-${terraform.workspace}"
-
-  tags = {
-    "Name" = "sierra-api-credentials-${terraform.workspace}"
-  }
 }
 
 data "aws_secretsmanager_secret_version" "sierra_api_credentials-sierra-api-key_version" {
   secret_id = aws_secretsmanager_secret.sierra_api_credentials.id
 }
 
-data "external" "sierra_api_credentials" {
-  program = ["echo", data.aws_secretsmanager_secret_version.sierra_api_credentials-sierra-api-key_version.secret_string]
-}
-
-# Azure AD
-
-resource "aws_secretsmanager_secret" "azure_ad_client_secret" {
-  name = "azure-ad-client-secret-${terraform.workspace}"
-
-  tags = {
-    "Name" = "azure-ad-client-secret-${terraform.workspace}"
-  }
-}
-
-data "aws_secretsmanager_secret_version" "azure_ad_client_secret_version" {
-  secret_id = aws_secretsmanager_secret.azure_ad_client_secret.id
-}
-
-# Email
-
-data "aws_secretsmanager_secret_version" "email_credentials_secret_version" {
-  secret_id = data.terraform_remote_state.identity_static.outputs.email_credential_secret_ids[terraform.workspace]
-}
-
-# Account Management System
-# Create these secrets in the experience account
-
-resource "aws_secretsmanager_secret" "account_management_system-auth0_client_secret" {
-  provider = aws.experience
-  name     = "identity/${terraform.workspace}/account_management_system/auth0_client_secret"
-
-  tags = {
-    "Name" = "identity/${terraform.workspace}/account_management_system/auth0_client_secret"
-  }
-}
-
-resource "aws_secretsmanager_secret_version" "account_management_system-auth0_client_secret" {
-  provider      = aws.experience
-  secret_id     = aws_secretsmanager_secret.account_management_system-auth0_client_secret.id
-  secret_string = auth0_client.account_management_system.client_secret
-}
-
-resource "aws_secretsmanager_secret" "account_management_system-api_key" {
-  provider = aws.experience
-  name     = "identity/${terraform.workspace}/account_management_system/api_key"
-
-  tags = {
-    "Name" = "identity/${terraform.workspace}/account_management_system/api_key"
-  }
-}
-
-resource "aws_secretsmanager_secret_version" "account_management_system-api_key" {
-  provider = aws.experience
-
-  secret_id     = aws_secretsmanager_secret.account_management_system-api_key.id
-  secret_string = aws_api_gateway_api_key.account_management_system.value
-}
-
-# Create these secrets in the identity account
-
-resource "aws_secretsmanager_secret" "account_management_system-api_key-identity" {
-  name = "identity/${terraform.workspace}/account_management_system/api_key"
-
-  tags = {
-    "Name" = "identity/${terraform.workspace}/account_management_system/api_key"
-  }
-}
-
-resource "aws_secretsmanager_secret_version" "account_management_system-api_key-identity" {
-  secret_id     = aws_secretsmanager_secret.account_management_system-api_key-identity.id
-  secret_string = aws_api_gateway_api_key.account_management_system.value
-}
-
-locals {
-  elasticsearch_apps  = ["requests"]
-  elasticsearch_creds = ["es_username", "es_password", "es_protocol", "es_port"]
-}
-
-resource "aws_secretsmanager_secret" "es_credentials" {
-  for_each = toset([
-    for path in setproduct(local.elasticsearch_apps, local.elasticsearch_creds) : "${path[0]}/${path[1]}"
-  ])
-
-  name = "identity/${terraform.workspace}/${each.value}"
-}
-
-# Smoke Test
-
-# The test_user credentials are set manually in SM
-data "aws_secretsmanager_secret" "test_user_credentials" {
+# The Sierra user credentials used in e2e tests are also set manually
+resource "aws_secretsmanager_secret" "test_user_credentials" {
   name = "identity/${terraform.workspace}/test_user/credentials"
 }
 
 data "aws_secretsmanager_secret_version" "test_user_credentials" {
-  secret_id = data.aws_secretsmanager_secret.test_user_credentials.id
+  secret_id = aws_secretsmanager_secret.test_user_credentials.id
 }
 
-# Setup a JSON secret to store
+# Email provider credentials
+# From the "static" stack - credentials are from mailtrap.io in stage and SES in prod
+data "aws_secretsmanager_secret_version" "email_credentials_secret_version" {
+  secret_id = data.terraform_remote_state.identity_static.outputs.email_credential_secret_ids[terraform.workspace]
+}
+
+# Prepare credentials we need to jsondecode or re-map
 locals {
-  decoded_test_user_credentials = jsondecode(
+  sierra_api_credentials_decoded = jsondecode(
+    data.aws_secretsmanager_secret_version.sierra_api_credentials-sierra-api-key_version.secret_string
+  )
+
+  sierra_api_credentials = {
+    client_key    = local.sierra_api_credentials_decoded["SierraAPIKey"]
+    client_secret = local.sierra_api_credentials_decoded["SierraAPISecret"]
+  }
+
+  test_user_credentials_decoded = jsondecode(
     data.aws_secretsmanager_secret_version.test_user_credentials.secret_string
   )
 
   smoke_test_credentials = {
-    username : local.decoded_test_user_credentials["username"]
-    password : local.decoded_test_user_credentials["password"]
+    username : local.test_user_credentials_decoded["username"]
+    password : local.test_user_credentials_decoded["password"]
     clientId : auth0_client.smoke_test.id
     clientSecret : auth0_client.smoke_test.client_secret
   }
@@ -128,30 +51,113 @@ locals {
   }
 }
 
-resource "aws_secretsmanager_secret" "smoke_test-auth0_credentials" {
-  name = "identity/${terraform.workspace}/smoke_test/credentials"
+# Secrets that we set in the identity account
+module "secrets" {
+  source = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.3.0"
 
-  tags = {
-    "Name" = "identity/${terraform.workspace}/smoke_test/auth0_client_secret"
+  key_value_map = {
+    "identity/${terraform.workspace}/account_management_system/api_key" = aws_api_gateway_api_key.account_management_system.value
+    "identity/${terraform.workspace}/buildkite/credentials"             = jsonencode(local.buildkite_credentials)
+    "identity/${terraform.workspace}/smoke_test/credentials"            = jsonencode(local.smoke_test_credentials)
   }
 }
 
-resource "aws_secretsmanager_secret_version" "smoke_test-auth0_credentials" {
-  secret_id     = aws_secretsmanager_secret.smoke_test-auth0_credentials.id
-  secret_string = jsonencode(local.smoke_test_credentials)
-}
+# Secrets that need to be exported to the experience account
+module "secrets_experience" {
+  source = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.3.0"
 
-# Buildkite
+  key_value_map = {
+    "identity/${terraform.workspace}/account_management_system/auth0_client_secret" = auth0_client.account_management_system.client_secret
+    "identity/${terraform.workspace}/account_management_system/api_key"             = aws_api_gateway_api_key.account_management_system.value
+  }
 
-resource "aws_secretsmanager_secret" "buildkite-auth0_credentials" {
-  name = "identity/${terraform.workspace}/buildkite/credentials"
-
-  tags = {
-    "Name" = "identity/${terraform.workspace}/buildkite/auth0_client_secret"
+  providers = {
+    aws = aws.experience
   }
 }
 
-resource "aws_secretsmanager_secret_version" "buildkite-auth0_credentials" {
-  secret_id     = aws_secretsmanager_secret.buildkite-auth0_credentials.id
-  secret_string = jsonencode(local.buildkite_credentials)
-}
+
+// TODO: These are here to remember what state to update in prod
+// TODO: Remove these once fully applied in prod
+//resource "aws_secretsmanager_secret" "account_management_system-auth0_client_secret" {
+//  provider = aws.experience
+//  name     = "identity/${terraform.workspace}/account_management_system/auth0_client_secret"
+//
+//  tags = {
+//    "Name" = "identity/${terraform.workspace}/account_management_system/auth0_client_secret"
+//  }
+//}
+//
+//resource "aws_secretsmanager_secret_version" "account_management_system-auth0_client_secret" {
+//  provider      = aws.experience
+//  secret_id     = aws_secretsmanager_secret.account_management_system-auth0_client_secret.id
+//  secret_string = auth0_client.account_management_system.client_secret
+//}
+//
+//resource "aws_secretsmanager_secret" "account_management_system-api_key" {
+//  provider = aws.experience
+//  name     = "identity/${terraform.workspace}/account_management_system/api_key"
+//
+//  tags = {
+//    "Name" = "identity/${terraform.workspace}/account_management_system/api_key"
+//  }
+//}
+//
+//resource "aws_secretsmanager_secret_version" "account_management_system-api_key" {
+//  provider = aws.experience
+//
+//  secret_id     = aws_secretsmanager_secret.account_management_system-api_key.id
+//  secret_string = aws_api_gateway_api_key.account_management_system.value
+//}
+
+//resource "aws_secretsmanager_secret" "account_management_system-api_key-identity" {
+//  name = "identity/${terraform.workspace}/account_management_system/api_key"
+//
+//  tags = {
+//    "Name" = "identity/${terraform.workspace}/account_management_system/api_key"
+//  }
+//}
+//
+//resource "aws_secretsmanager_secret_version" "account_management_system-api_key-identity" {
+//  secret_id     = aws_secretsmanager_secret.account_management_system-api_key-identity.id
+//  secret_string = aws_api_gateway_api_key.account_management_system.value
+//}
+
+//locals {
+//  elasticsearch_apps  = ["requests"]
+//  elasticsearch_creds = ["es_username", "es_password", "es_protocol", "es_port"]
+//}
+//
+//resource "aws_secretsmanager_secret" "es_credentials" {
+//  for_each = toset([
+//    for path in setproduct(local.elasticsearch_apps, local.elasticsearch_creds) : "${path[0]}/${path[1]}"
+//  ])
+//
+//  name = "identity/${terraform.workspace}/${each.value}"
+//}
+
+//resource "aws_secretsmanager_secret" "buildkite-auth0_credentials" {
+//  name = "identity/${terraform.workspace}/buildkite/credentials"
+//
+//  tags = {
+//    "Name" = "identity/${terraform.workspace}/buildkite/auth0_client_secret"
+//  }
+//}
+//
+//resource "aws_secretsmanager_secret_version" "buildkite-auth0_credentials" {
+//  secret_id     = aws_secretsmanager_secret.buildkite-auth0_credentials.id
+//  secret_string = jsonencode(local.buildkite_credentials)
+//}
+
+//resource "aws_secretsmanager_secret" "smoke_test-auth0_credentials" {
+//  name = "identity/${terraform.workspace}/smoke_test/credentials"
+//
+//  tags = {
+//    "Name" = "identity/${terraform.workspace}/smoke_test/auth0_client_secret"
+//  }
+//}
+//
+//resource "aws_secretsmanager_secret_version" "smoke_test-auth0_credentials" {
+//  secret_id     = aws_secretsmanager_secret.smoke_test-auth0_credentials.id
+//  secret_string = jsonencode(local.smoke_test_credentials)
+//}


### PR DESCRIPTION
In order to make secrets handling in the identity stack more familiar, this change:

- Uses the terraform secrets module: https://github.com/wellcomecollection/terraform-aws-secrets
- Removes the use of the `data.external` resource to parse JSON
- Adding a few comments intended to clarify the source & use of resources