### PR TITLE
Add OpenAthens callback URL to config

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -188,8 +188,13 @@ resource "auth0_client" "openathens_saml_idp" {
   app_type       = "regular_web"
   is_first_party = true
 
+  callbacks = [
+    data.aws_secretsmanager_secret_version.openathens_callback_url.secret_string
+  ]
+
   addons {
     samlp {
+
       mappings = {
         user_id     = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
         email       = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -17,6 +17,15 @@ data "aws_secretsmanager_secret_version" "test_user_credentials" {
   secret_id = aws_secretsmanager_secret.test_user_credentials.id
 }
 
+# OpenAthens configuration
+resource "aws_secretsmanager_secret" "openathens_callback_url" {
+  name = "identity/openathens_callback_url"
+}
+
+data "aws_secretsmanager_secret_version" "openathens_callback_url" {
+  secret_id = aws_secretsmanager_secret.openathens_callback_url.id
+}
+
 # Email provider credentials
 # From the "static" stack - credentials are from mailtrap.io in stage and SES in prod
 data "aws_secretsmanager_secret_version" "email_credentials_secret_version" {


### PR DESCRIPTION
In order to enable the OpenAthens sign-in for e-resources we need to add the callback URL provided by them to our config.

This change does that and stores the value provided by the SAML connector config for "Assertion Consumer Service URL" in secrets manager (I don't think this necessarily must be secret, but erring on the side of caution).