### PR TITLE
Change backToLoginLinkText for the reset password screen

### DIFF
--- a/universal_login/prompt/reset-password.json
+++ b/universal_login/prompt/reset-password.json
@@ -7,7 +7,8 @@
   "reset-password-request": {
     "pageTitle": "Forgotten password",
     "descriptionEmail": "Enter the email address you use to log in. We’ll send you a link to reset your password.",
-    "buttonText": "Send password reset"
+    "buttonText": "Send password reset",
+    "backToLoginLinkText": "Back to sign in"
   },
   "reset-password-email": {
     "pageTitle": "Forgotten password",


### PR DESCRIPTION
Change forgotten password screen back link from 'Back to Account Management System' to 'Back to sign in'.