### PR TITLE
prevent us hitting the API rate limit

### DIFF
--- a/universal_login/deploy.ts
+++ b/universal_login/deploy.ts
@@ -202,11 +202,10 @@ async function updateEmail(env: Env, email: Email, token: BearerToken) {
 
     const token = await getApiToken(env);
     // The non production rate limit of the API end point is 2 requests a second, this ensures we never hit the limit
-    const delay = (milliseconds: number) =>
-      new Promise((res) => setTimeout(res, milliseconds));
+    const delay = () => new Promise((res) => setTimeout(res, 1000));
 
     for (const prompt of prompts) {
-      await delay(1000);
+      await delay();
       console.log(`Updating ${prompt} prompt`);
       await updateTextPrompt(env, prompt, token);
     }
@@ -215,7 +214,7 @@ async function updateEmail(env: Env, email: Email, token: BearerToken) {
     await updateLoginPageTemplate(env, 'universal-login', token);
 
     for (const email of emails) {
-      await delay(1000);
+      await delay();
       console.log(`Updating ${email} email`);
       await updateEmail(env, email, token);
     }

--- a/universal_login/deploy.ts
+++ b/universal_login/deploy.ts
@@ -201,8 +201,12 @@ async function updateEmail(env: Env, email: Email, token: BearerToken) {
     console.log(`Updating environment: ${env}`);
 
     const token = await getApiToken(env);
+    // The non production rate limit of the API end point is 2 requests a second, this ensures we never hit the limit
+    const delay = (milliseconds: number) =>
+      new Promise((res) => setTimeout(res, milliseconds));
 
     for (const prompt of prompts) {
+      await delay(1000);
       console.log(`Updating ${prompt} prompt`);
       await updateTextPrompt(env, prompt, token);
     }
@@ -211,6 +215,7 @@ async function updateEmail(env: Env, email: Email, token: BearerToken) {
     await updateLoginPageTemplate(env, 'universal-login', token);
 
     for (const email of emails) {
+      await delay(1000);
       console.log(`Updating ${email} email`);
       await updateEmail(env, email, token);
     }


### PR DESCRIPTION
When deploying to stage the build can sometimes fail because we exceed the [rate limit for the Auth0 API endpoint](https://auth0.com/docs/support/policies/rate-limit-policy/management-api-endpoint-rate-limits)

This stops that from happening