### PR TITLE
Include caller ID as a custom header on the requests api integration

### DIFF
--- a/infra/scoped/api-integration.tf
+++ b/infra/scoped/api-integration.tf
@@ -349,6 +349,10 @@ resource "aws_api_gateway_integration" "users_userid_item-requests_post" {
 
   request_parameters = {
     "integration.request.path.userId" = "method.request.path.userId"
+
+    // This must be set to pass the context set by the authorizer to the HTTP integration
+    // See: https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html
+    "integration.request.header.X-Wellcome-Caller-ID" = "context.authorizer.callerId"
   }
 }
 
@@ -367,5 +371,9 @@ resource "aws_api_gateway_integration" "users_userid_item-requests_get" {
 
   request_parameters = {
     "integration.request.path.userId" = "method.request.path.userId"
+
+    // This must be set to pass the context set by the authorizer to the HTTP integration
+    // See: https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html
+    "integration.request.header.X-Wellcome-Caller-ID" = "context.authorizer.callerId"
   }
 }


### PR DESCRIPTION
The context added by the custom authorizer is automatically passed to the Lambda API, but needs manual intervention to work for HTTP proxy integrations