### PR TITLE
Un-drift terraform

### DIFF
--- a/infra/scoped/auth0-email.tf
+++ b/infra/scoped/auth0-email.tf
@@ -1,0 +1,12 @@
+resource "auth0_email" "email" {
+  name                 = "smtp"
+  enabled              = true
+  default_from_address = local.email_noreply_name_and_address
+
+  credentials {
+    smtp_host = local.email_credentials["smtp_hostname"]
+    smtp_port = 587
+    smtp_user = local.email_credentials["smtp_username"]
+    smtp_pass = local.email_credentials["smtp_password"]
+  }
+}

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -11,6 +11,7 @@ locals {
   stage_test_client_ids = compact([
     length(auth0_client.dummy_test) > 0 ? auth0_client.dummy_test[0].client_id : "",
     # Developer client ids can be added here
+    "SrigIHZ3yXKlskZcdxJeytBuHqUUw7gn" // "David McCormick – Local Dev"
   ])
 
   # Terraform

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -19,7 +19,7 @@ data "aws_secretsmanager_secret_version" "test_user_credentials" {
 
 # OpenAthens configuration
 resource "aws_secretsmanager_secret" "openathens_callback_url" {
-  name = "identity/openathens_callback_url"
+  name = "identity/${terraform.workspace}/openathens_callback_url"
 }
 
 data "aws_secretsmanager_secret_version" "openathens_callback_url" {


### PR DESCRIPTION
Restores the email config (not templates) that https://github.com/wellcomecollection/identity/pull/194 removed; did some `state rm`ing and `import`ing to sort the rest out

(already applied)