### PR TITLE
Update 'from' email

### DIFF
--- a/universal_login/emails/blocked_account.json
+++ b/universal_login/emails/blocked_account.json
@@ -1,6 +1,6 @@
 {
   "template": "blocked_account",
-  "from": "library@wellcomecollection.org <library@wellcomecollection.org>",
+  "from": "Library Enquiries <library@wellcomecollection.org>",
   "subject": "Blocked account",
   "syntax": "liquid",
   "enabled": true

--- a/universal_login/emails/blocked_account.json
+++ b/universal_login/emails/blocked_account.json
@@ -1,6 +1,6 @@
 {
   "template": "blocked_account",
-  "from": "library@wellcomecollection.org",
+  "from": "library@wellcomecollection.org <library@wellcomecollection.org>",
   "subject": "Blocked account",
   "syntax": "liquid",
   "enabled": true

--- a/universal_login/emails/reset_email.json
+++ b/universal_login/emails/reset_email.json
@@ -1,6 +1,6 @@
 {
   "template": "reset_email",
-  "from": "library@wellcomecollection.org <library@wellcomecollection.org>",
+  "from": "Library Enquiries <library@wellcomecollection.org>",
   "subject": "Reset your password",
   "syntax": "liquid",
   "enabled": true

--- a/universal_login/emails/reset_email.json
+++ b/universal_login/emails/reset_email.json
@@ -1,6 +1,6 @@
 {
   "template": "reset_email",
-  "from": "library@wellcomecollection.org",
+  "from": "library@wellcomecollection.org <library@wellcomecollection.org>",
   "subject": "Reset your password",
   "syntax": "liquid",
   "enabled": true

--- a/universal_login/emails/verify_email.json
+++ b/universal_login/emails/verify_email.json
@@ -1,6 +1,6 @@
 {
   "template": "verify_email",
-  "from": "library@wellcomecollection.org",
+  "from": "library@wellcomecollection.org <library@wellcomecollection.org>",
   "resultUrl": "https://wellcomecollection.org/account/validated",
   "subject": "Verify your email address",
   "syntax": "liquid",

--- a/universal_login/emails/verify_email.json
+++ b/universal_login/emails/verify_email.json
@@ -1,6 +1,6 @@
 {
   "template": "verify_email",
-  "from": "library@wellcomecollection.org <library@wellcomecollection.org>",
+  "from": "Library Enquiries <library@wellcomecollection.org>",
   "resultUrl": "https://wellcomecollection.org/account/validated",
   "subject": "Verify your email address",
   "syntax": "liquid",

--- a/universal_login/emails/welcome_email.json
+++ b/universal_login/emails/welcome_email.json
@@ -1,6 +1,6 @@
 {
   "template": "welcome_email",
-  "from": "library@wellcomecollection.org <library@wellcomecollection.org>",
+  "from": "Library Enquiries <library@wellcomecollection.org>",
   "subject": "Welcome to Wellcome Collection",
   "syntax": "liquid",
   "enabled": true

--- a/universal_login/emails/welcome_email.json
+++ b/universal_login/emails/welcome_email.json
@@ -1,6 +1,6 @@
 {
   "template": "welcome_email",
-  "from": "library@wellcomecollection.org",
+  "from": "library@wellcomecollection.org <library@wellcomecollection.org>",
   "subject": "Welcome to Wellcome Collection",
   "syntax": "liquid",
   "enabled": true


### PR DESCRIPTION
Fixes wellcomecollection/wellcomecollection.org#7134

Use `Library Enquiries <library@wellcomecollection.org>` for 'from' email address.