### PR TITLE
Add password validation to significant operations

### DIFF
--- a/infra/scoped/api-gateway.tf
+++ b/infra/scoped/api-gateway.tf
@@ -1447,6 +1447,10 @@ resource "aws_api_gateway_method" "users_userid_deletion-request_put" {
   request_parameters = {
     "method.request.path.userId" = true
   }
+
+  request_models = {
+    "application/json" = aws_api_gateway_model.deletion-request.name
+  }
 }
 
 # 200 OK

--- a/infra/scoped/api-model.tf
+++ b/infra/scoped/api-model.tf
@@ -33,6 +33,13 @@ resource "aws_api_gateway_model" "update-user" {
   schema       = file("${path.module}/../../models/update-user.json")
 }
 
+resource "aws_api_gateway_model" "deletion-request" {
+  name         = "DeletionRequest"
+  rest_api_id  = aws_api_gateway_rest_api.identity.id
+  content_type = "application/json"
+  schema       = file("${path.module}/../../models/deletion-request.json")
+}
+
 resource "aws_api_gateway_model" "validate" {
   name         = "Validate"
   rest_api_id  = aws_api_gateway_rest_api.identity.id

--- a/models/deletion-request.json
+++ b/models/deletion-request.json
@@ -1,17 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "title": "Update Password Schema",
+  "title": "Deletion Request Schema",
   "type": "object",
   "properties": {
     "password": {
       "type": "string",
       "minLength": 1
-    },
-    "newPassword": {
-      "type": "string",
-      "minLength": 1
     }
   },
-  "required": ["password", "newPassword"],
+  "required": ["password"],
   "additionalProperties": false
 }

--- a/models/update-user.json
+++ b/models/update-user.json
@@ -3,6 +3,10 @@
   "title": "Update User Schema",
   "type": "object",
   "properties": {
+    "password": {
+      "type": "string",
+      "minLength": 1
+    },
     "email": {
       "type": "string",
       "format": "email"

--- a/packages/apps/api/src/handlers/errorHandler.ts
+++ b/packages/apps/api/src/handlers/errorHandler.ts
@@ -14,4 +14,9 @@ export const errorHandler = (
 
   const status = err instanceof HttpError ? err.status : 500;
   res.status(status).json(err.message ? toMessage(err.message) : undefined);
+
+  // These are unexpected errors
+  if (!(err instanceof HttpError)) {
+    console.error(err);
+  }
 };

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -19,6 +19,7 @@ import { toSearchResults, toUser } from '../models/user';
 import { EmailClient } from '../utils/EmailClient';
 
 export function validatePassword(auth0Client: Auth0Client) {
+  const checkPassword = passwordCheckerForUser(auth0Client);
   return async function (request: Request, response: Response): Promise<void> {
     const userId: number = getTargetUserId(request);
     const password: string = request.body.password;
@@ -28,7 +29,6 @@ export function validatePassword(auth0Client: Auth0Client) {
         message: 'A password must be provided and non-blank',
       });
     }
-
     const auth0Get: APIResponse<Auth0Profile> = await auth0Client.getUserByUserId(
       userId
     );
@@ -36,14 +36,11 @@ export function validatePassword(auth0Client: Auth0Client) {
       throw clientResponseToHttpError(auth0Get);
     }
 
-    const validationResult = await auth0Client.validateUserCredentials(
-      extractSourceIp(request),
+    await checkPassword(
       auth0Get.result.email,
-      password
+      password,
+      extractSourceIp(request)
     );
-    if (validationResult.status !== ResponseStatus.Success) {
-      throw clientResponseToHttpError(validationResult);
-    }
 
     response.sendStatus(200);
   };
@@ -159,8 +156,10 @@ export function updateUser(
   sierraClient: SierraClient,
   auth0Client: Auth0Client
 ) {
+  const checkPassword = passwordCheckerForUser(auth0Client);
   return async function (request: Request, response: Response): Promise<void> {
     const userId: number = getTargetUserId(request);
+    const password: string | undefined = request.body.password;
 
     const auth0UserIdGet: APIResponse<Auth0Profile> = await auth0Client.getUserByUserId(
       userId
@@ -169,6 +168,21 @@ export function updateUser(
       throw clientResponseToHttpError(auth0UserIdGet);
     }
     const auth0Profile: Auth0Profile = auth0UserIdGet.result;
+
+    if (!userIsAdmin(request)) {
+      if (!password) {
+        throw new HttpError({
+          status: 400,
+          message: 'Current password must be provided',
+        });
+      }
+
+      await checkPassword(
+        auth0Profile.email,
+        password,
+        extractSourceIp(request)
+      );
+    }
 
     const fields: { [key: string]: { value: string; modified: boolean } } = {
       email: {
@@ -287,20 +301,31 @@ export function changePassword(
   sierraClient: SierraClient,
   auth0Client: Auth0Client
 ) {
+  const checkPassword = passwordCheckerForUser(auth0Client);
   return async function (request: Request, response: Response): Promise<void> {
     const userId: number = getTargetUserId(request);
 
-    const password: string = request.body.password;
-    if (!isNonBlank(password)) {
+    const newPassword: string = request.body.newPassword;
+    const oldPassword: string = request.body.password;
+    if (!isNonBlank(newPassword) || !isNonBlank(oldPassword)) {
       throw new HttpError({
         status: 400,
         message: 'All fields must be provided and non-blank',
       });
     }
 
+    const auth0Get: APIResponse<Auth0Profile> = await auth0Client.getUserByUserId(
+      userId
+    );
+    if (auth0Get.status !== ResponseStatus.Success) {
+      throw clientResponseToHttpError(auth0Get);
+    }
+    const sss = extractSourceIp(request);
+    const pogs = await checkPassword(auth0Get.result.email, oldPassword, sss);
+
     const auth0Update: APIResponse<Auth0Profile> = await auth0Client.updatePassword(
       userId,
-      password
+      newPassword
     );
     if (auth0Update.status !== ResponseStatus.Success) {
       throw clientResponseToHttpError(auth0Update);
@@ -308,7 +333,7 @@ export function changePassword(
 
     const sierraUpdate: APIResponse<PatronRecord> = await sierraClient.updatePassword(
       userId,
-      truncate(password, 30)
+      truncate(newPassword, 30)
     );
     if (sierraUpdate.status !== ResponseStatus.Success) {
       throw clientResponseToHttpError(sierraUpdate);
@@ -447,8 +472,10 @@ export function requestDelete(
   auth0Client: Auth0Client,
   emailClient: EmailClient
 ) {
+  const checkPassword = passwordCheckerForUser(auth0Client);
   return async function (request: Request, response: Response): Promise<void> {
     const userId: number = getTargetUserId(request);
+    const password: string = request.body.password;
 
     const auth0Get: APIResponse<Auth0Profile> = await auth0Client.getUserByUserId(
       userId
@@ -456,6 +483,12 @@ export function requestDelete(
     if (auth0Get.status !== ResponseStatus.Success) {
       throw clientResponseToHttpError(auth0Get);
     }
+
+    await checkPassword(
+      auth0Get.result.email,
+      password,
+      extractSourceIp(request)
+    );
 
     if (auth0Get.result?.metadata?.deleteRequested) {
       response
@@ -673,4 +706,21 @@ function userIsAdmin(request: Request): boolean {
   const isAdmin: string | null | undefined =
     request.apiGateway?.event.requestContext.authorizer?.isAdmin;
   return !!isAdmin && /true/i.test(isAdmin);
+}
+
+function passwordCheckerForUser(auth0Client: Auth0Client) {
+  return async function (
+    email: string,
+    password: string,
+    sourceIp: string
+  ): Promise<void> {
+    const validationResult = await auth0Client.validateUserCredentials(
+      sourceIp,
+      email,
+      password
+    );
+    if (validationResult.status !== ResponseStatus.Success) {
+      throw clientResponseToHttpError(validationResult);
+    }
+  };
 }

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -320,8 +320,12 @@ export function changePassword(
     if (auth0Get.status !== ResponseStatus.Success) {
       throw clientResponseToHttpError(auth0Get);
     }
-    const sss = extractSourceIp(request);
-    const pogs = await checkPassword(auth0Get.result.email, oldPassword, sss);
+
+    await checkPassword(
+      auth0Get.result.email,
+      oldPassword,
+      extractSourceIp(request)
+    );
 
     const auth0Update: APIResponse<Auth0Profile> = await auth0Client.updatePassword(
       userId,


### PR DESCRIPTION
Some operations should require the user's current password to be validated in order for them to succeed. Rather than doing this in the client with 2 separate API calls, this PR makes it so that the relevant endpoints validate the password themselves.