### PR TITLE
Add extra required scripts for legacy DB connections

### DIFF
--- a/.buildkite/scripts/auth0-deployment.sh
+++ b/.buildkite/scripts/auth0-deployment.sh
@@ -21,6 +21,8 @@ function __do_deployment() {
   cp -v /app/.buildkite/build/change_password.js "/app/.buildkite/build/auth0-export/database-connections/${AUTH0_CONNECTION_NAME}/"
   cp -v /app/.buildkite/build/change_email.js "/app/.buildkite/build/auth0-export/database-connections/${AUTH0_CONNECTION_NAME}/"
   cp -v /app/.buildkite/build/verify.js "/app/.buildkite/build/auth0-export/database-connections/${AUTH0_CONNECTION_NAME}/"
+  cp -v /app/.buildkite/build/create.js "/app/.buildkite/build/auth0-export/database-connections/${AUTH0_CONNECTION_NAME}/"
+  cp -v /app/.buildkite/build/delete.js "/app/.buildkite/build/auth0-export/database-connections/${AUTH0_CONNECTION_NAME}/"
   cp -v /app/.buildkite/build/enrich_userinfo.js "/app/.buildkite/build/auth0-export/rules/${AUTH0_ENRICH_USERINFO_RULE_NAME}.js"
 
   a0deploy import --input_file "/app/.buildkite/build/auth0-export/"

--- a/.buildkite/scripts/auth0-packaging.sh
+++ b/.buildkite/scripts/auth0-packaging.sh
@@ -14,6 +14,8 @@ function __package_auth0_scripts() {
     "/app/packages/apps/auth0-actions/dist/change_password.js" \
     "/app/packages/apps/auth0-actions/dist/change_email.js" \
     "/app/packages/apps/auth0-actions/dist/verify.js" \
+    "/app/packages/apps/auth0-actions/dist/create.js" \
+    "/app/packages/apps/auth0-actions/dist/delete.js" \
     "/app/packages/apps/auth0-actions/dist/enrich_userinfo.js"
 }
 

--- a/infra/scoped/auth0-connection.tf
+++ b/infra/scoped/auth0-connection.tf
@@ -44,6 +44,8 @@ resource "auth0_connection" "sierra" {
       change_password = file("${path.module}/data/empty.js"),
       change_email    = file("${path.module}/data/empty.js"),
       verify          = file("${path.module}/data/empty.js"),
+      create          = file("${path.module}/data/empty.js"),
+      delete          = file("${path.module}/data/empty.js"),
     }
 
     configuration = {

--- a/packages/apps/auth0-actions/TaskWrapperPlugin.js
+++ b/packages/apps/auth0-actions/TaskWrapperPlugin.js
@@ -6,7 +6,7 @@ const {
 const pluginName = 'TaskWrapperPlugin';
 
 // This wraps single-chunk assets in a function named `[chunkName]_wrapper`,
-// which assumes that there is a function called `[chunkName]` in scope and calls
+// which assumes that there is a function called `[chunkName]_script` in scope and calls
 // it with the same arguments.
 //
 // It is necessary because auth0 scripts want everything to be wrapped in a single function
@@ -48,7 +48,7 @@ class TaskWrapperPlugin {
     return new ConcatSource(
       `function ${chunkName}_wrapper(...args) {\n`,
       source,
-      `\n${chunkName}.apply(this, args);\n}`
+      `\n${chunkName}_script.apply(this, args);\n}`
     );
   }
 }

--- a/packages/apps/auth0-actions/src/create.ts
+++ b/packages/apps/auth0-actions/src/create.ts
@@ -1,0 +1,9 @@
+import { callbackify } from 'util';
+import { User } from 'auth0';
+
+async function create(user: User) {
+  // We don't (yet) create users in Auth0 so we don't need to create them in Sierra
+  console.log('User created: ', user.user_id);
+}
+
+export default callbackify(create);

--- a/packages/apps/auth0-actions/src/delete.ts
+++ b/packages/apps/auth0-actions/src/delete.ts
@@ -1,0 +1,8 @@
+import { callbackify } from 'util';
+
+async function deleteUser(id: string) {
+  // We don't actually want to delete the user from Sierra
+  console.log('User deleted: ', id);
+}
+
+export default callbackify(deleteUser);

--- a/packages/apps/auth0-actions/src/helpers.ts
+++ b/packages/apps/auth0-actions/src/helpers.ts
@@ -19,6 +19,12 @@ export const recordNumberForEmail = async (
   if (patronRecordResponse.status === ResponseStatus.Success) {
     return patronRecordResponse.result.recordNumber;
   } else if (patronRecordResponse.status === ResponseStatus.NotFound) {
+    // We return undefined rather than an error here because the Auth0 scripts
+    // are not expected to treat a missing user as an error
+    // See https://auth0.com/docs/connections/database/custom-db/templates/change-email
+    //
+    // > no corresponding second parameter (or one with a value of false) indicates that no
+    // > password change was performed (possibly due to the user not being found)
     return undefined;
   } else {
     throw new Error(patronRecordResponse.message);

--- a/packages/apps/auth0-actions/webpack.config.js
+++ b/packages/apps/auth0-actions/webpack.config.js
@@ -10,6 +10,8 @@ const actions = [
   'change_password',
   'change_email',
   'verify',
+  'create',
+  'delete',
 ];
 
 // Any non-node external modules should be listed here

--- a/packages/apps/auth0-actions/webpack.config.js
+++ b/packages/apps/auth0-actions/webpack.config.js
@@ -66,9 +66,10 @@ module.exports = {
     filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),
     // This config means that the output declares a `var` named as the chunk name
-    // to which the default export of the script is assigned.
+    // to which the default export of the script is assigned, with the suffix `_script`
+    // in case the chunk name is not a valid identifier.
     library: {
-      name: '[name]',
+      name: '[name]_script',
       type: 'var',
       export: 'default',
     },


### PR DESCRIPTION
These scripts - `create` and `delete` don't actually modify Sierra, but Auth0 needs them