### PR TITLE
It is not necessary to check whether a user exists before changing email

### DIFF
--- a/packages/apps/auth0-actions/jest.setup.js
+++ b/packages/apps/auth0-actions/jest.setup.js
@@ -12,11 +12,5 @@ class WrongUsernameOrPasswordError extends Error {
     super(message);
   }
 }
-class ValidationError extends Error {
-  constructor(errorId, message) {
-    super(message);
-  }
-}
 
 global.WrongUsernameOrPasswordError = WrongUsernameOrPasswordError;
-global.ValidationError = ValidationError;

--- a/packages/apps/auth0-actions/src/change_email.ts
+++ b/packages/apps/auth0-actions/src/change_email.ts
@@ -27,21 +27,10 @@ async function changeEmail(
     return false;
   }
 
-  const userWithEmailExists = Boolean(
-    await recordNumberForEmail(newEmail, sierraClient)
-  );
-  if (userWithEmailExists) {
-    throw new ValidationError(
-      'user-exists',
-      'The specified new email already exists in Sierra'
-    );
-  }
-
   const patronRecordUpdate = await sierraClient.updatePatronRecord(
     recordNumber,
     newEmail
   );
-
   if (patronRecordUpdate.status !== ResponseStatus.Success) {
     throw new Error(patronRecordUpdate.message);
   }

--- a/packages/apps/auth0-actions/src/databaseScriptGlobals.d.ts
+++ b/packages/apps/auth0-actions/src/databaseScriptGlobals.d.ts
@@ -6,7 +6,4 @@ declare global {
   class WrongUsernameOrPasswordError extends Error {
     constructor(emailOrId?: string, message?: string);
   }
-  class ValidationError extends Error {
-    constructor(errorId: string, message: string);
-  }
 }

--- a/packages/apps/auth0-actions/tests/change_email.test.ts
+++ b/packages/apps/auth0-actions/tests/change_email.test.ts
@@ -56,27 +56,6 @@ describe('change email script', () => {
     );
   });
 
-  it('throws a ValidationError if a user with the new email already exists in Sierra', (done) => {
-    const testPatron = MockSierraClient.randomPatronRecord();
-    const existingPatron = MockSierraClient.randomPatronRecord();
-    mockSierraClient.addPatron(testPatron);
-    mockSierraClient.addPatron(existingPatron);
-
-    const callback = (
-      error?: NodeJS.ErrnoException | null,
-      success?: boolean
-    ) => {
-      expect(error).toBeInstanceOf(ValidationError);
-      expect(
-        error?.message.includes('The specified new email already exists')
-      ).toBe(true);
-      expect(success).toBeUndefined();
-      done();
-    };
-
-    changeEmail(testPatron.email, existingPatron.email, false, callback);
-  });
-
   it('throws an error if the Sierra request returns an error', (done) => {
     const testPatron = MockSierraClient.randomPatronRecord();
     mockSierraClient.addPatron(testPatron);


### PR DESCRIPTION
I tried to do the right thing here, but Auth0 is actually doing it for us - as per [this thread](https://community.auth0.com/t/changing-email-via-the-api-returns-the-specified-new-email-already-exists-when-it-doesnt/38838):
> Everything you do against that connection; registering, password resets, changing email, will trigger the GetUser request and query your local DB for a user with that email

(I have verified that this is the case)