### PR TITLE
Additional authorizer bits and pieces

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -163,6 +163,21 @@ resource "auth0_client" "account_management_system" {
   }
 }
 
+resource "auth0_client_grant" "account_management_system" {
+  client_id = auth0_client.account_management_system.client_id
+  audience  = auth0_resource_server.identity_api.identifier
+
+  // Be explicit about these scopes so as not to accidentally give too many permissions
+  scope = [
+    "create:requests",
+    "delete:patron",
+    "read:user",
+    "read:requests",
+    "update:email",
+    "update:password"
+  ]
+}
+
 # OpenAthens SAML Identity Provider
 # Allows OpenAthens to authenticate users against the Auth0 user-pool
 
@@ -209,4 +224,10 @@ resource "auth0_client" "smoke_test" {
   ]
 
   callbacks = []
+}
+
+resource "auth0_client_grant" "smoke_test" {
+  client_id = auth0_client.smoke_test.client_id
+  audience  = auth0_resource_server.identity_api.identifier
+  scope     = [for scope in auth0_resource_server.identity_api.scopes : scope.value]
 }

--- a/packages/apps/api/test/routes/fixtures/mockedApi.ts
+++ b/packages/apps/api/test/routes/fixtures/mockedApi.ts
@@ -30,9 +30,11 @@ const apiGatewayHeaders = (data: object = {}) => {
 const withApiGatewayContext = (data: object) => (request: Request) =>
   request.set(apiGatewayHeaders(data));
 
-export const withSourceIp = withApiGatewayContext({
-  identity: { sourceIp: 'test' },
-});
+export const withCallerId = (id: string | number) =>
+  withApiGatewayContext({
+    authorizer: { callerId: id },
+    identity: { sourceIp: 'test' },
+  });
 
 export const mockedApi = (existingUsers: ExistingUser[] = []) => {
   const mockClients = {

--- a/packages/apps/api/test/routes/users_user_id.test.ts
+++ b/packages/apps/api/test/routes/users_user_id.test.ts
@@ -1,4 +1,4 @@
-import { mockedApi, withSourceIp } from './fixtures/mockedApi';
+import { mockedApi, withCallerId } from './fixtures/mockedApi';
 import { randomExistingUser } from './fixtures/generators';
 
 describe('/users/{userId}', () => {
@@ -6,7 +6,9 @@ describe('/users/{userId}', () => {
     it('fetches a user', async () => {
       const testUser = randomExistingUser();
       const { api } = mockedApi([testUser]);
-      const response = await api.get(`/users/${testUser.userId}`);
+      const response = await withCallerId(testUser.userId)(
+        api.get(`/users/${testUser.userId}`)
+      );
 
       expect(response.statusCode).toBe(200);
       expect(response.body.userId).toBe(testUser.userId);
@@ -17,7 +19,8 @@ describe('/users/{userId}', () => {
 
     it('404s for users that do not exist', async () => {
       const { api } = mockedApi();
-      const response = await api.get(`/users/6666666`);
+      const id = 6666666;
+      const response = await withCallerId(id)(api.get(`/users/${id}`));
 
       expect(response.statusCode).toBe(404);
     });
@@ -27,7 +30,7 @@ describe('/users/{userId}', () => {
     it('updates a user', async () => {
       const testUser = randomExistingUser({ password: 'test-password' });
       const { api } = mockedApi([testUser]);
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser.userId)(
         api
           .put(`/users/${testUser.userId}`)
           .send({ email: 'test2@test.com', password: testUser.password })
@@ -44,7 +47,7 @@ describe('/users/{userId}', () => {
     it('fails if the correct current password is not provided', async () => {
       const testUser = randomExistingUser({ password: 'test-password' });
       const { api } = mockedApi([testUser]);
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser.userId)(
         api
           .put(`/users/${testUser.userId}`)
           .send({ email: 'test2@test.com', password: 'wrong' })
@@ -58,7 +61,7 @@ describe('/users/{userId}', () => {
       const testUser1 = randomExistingUser({ password: 'test-password' });
       const testUser2 = randomExistingUser();
       const { api } = mockedApi([testUser1, testUser2]);
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser1.userId)(
         api
           .put(`/users/${testUser1.userId}`)
           .send({ email: testUser2.email, password: testUser1.password })

--- a/packages/apps/api/test/routes/users_user_id_deletion-request.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_deletion-request.test.ts
@@ -1,4 +1,4 @@
-import { mockedApi, withSourceIp } from './fixtures/mockedApi';
+import { mockedApi, withCallerId } from './fixtures/mockedApi';
 import { randomExistingUser } from './fixtures/generators';
 
 describe('/users/{userId}/deletion-request', () => {
@@ -6,7 +6,7 @@ describe('/users/{userId}/deletion-request', () => {
     it('marks a user as having requested deletion, blocks the account, and sends deletion request emails', async () => {
       const testUser = randomExistingUser({ password: 'test-password' });
       const { clients, api } = mockedApi([testUser]);
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser.userId)(
         api
           .put(`/users/${testUser.userId}/deletion-request`)
           .send({ password: testUser.password })
@@ -25,7 +25,7 @@ describe('/users/{userId}/deletion-request', () => {
     it('fails if the correct current password is not provided', async () => {
       const testUser = randomExistingUser({ password: 'test-password' });
       const { api } = mockedApi([testUser]);
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser.userId)(
         api
           .put(`/users/${testUser.userId}/deletion-request`)
           .send({ password: 'wrong' })
@@ -40,7 +40,7 @@ describe('/users/{userId}/deletion-request', () => {
         password: 'test-password',
       });
       const { api } = mockedApi([testUser]);
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser.userId)(
         api
           .put(`/users/${testUser.userId}/deletion-request`)
           .send({ password: testUser.password })
@@ -51,7 +51,10 @@ describe('/users/{userId}/deletion-request', () => {
 
     it('404s for users that do not exist', async () => {
       const { api } = mockedApi();
-      const response = await api.put(`/users/6666666/deletion-request`);
+      const id = 6666666;
+      const response = await withCallerId(id)(
+        api.put(`/users/${id}/deletion-request`)
+      );
       expect(response.statusCode).toBe(404);
     });
   });

--- a/packages/apps/api/test/routes/users_user_id_password.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_password.test.ts
@@ -1,4 +1,4 @@
-import { mockedApi, withSourceIp } from './fixtures/mockedApi';
+import { mockedApi, withCallerId } from './fixtures/mockedApi';
 import { ResponseStatus } from '@weco/identity-common';
 import { randomExistingUser } from './fixtures/generators';
 
@@ -10,7 +10,7 @@ describe('/users/{userId}/password', () => {
       const testUser = randomExistingUser({ password: oldPassword });
       const { api, clients } = mockedApi([testUser]);
 
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser.userId)(
         api
           .put(`/users/${testUser.userId}/password`)
           .send({ newPassword, password: oldPassword })
@@ -33,7 +33,7 @@ describe('/users/{userId}/password', () => {
       const testUser = randomExistingUser({ password: oldPassword });
       const { api } = mockedApi([testUser]);
 
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser.userId)(
         api
           .put(`/users/${testUser.userId}/password`)
           .send({ newPassword, password: 'wrong' })
@@ -45,10 +45,13 @@ describe('/users/{userId}/password', () => {
 
     it('404s for users that do not exist', async () => {
       const { api } = mockedApi();
-      const response = await api
-        .put(`/users/66666666/password`)
-        .send({ newPassword: 'new-password', password: 'old-password' })
-        .set('Accept', 'application/json');
+      const id = 6666666;
+      const response = await withCallerId(id)(
+        api
+          .put(`/users/${id}/password`)
+          .send({ newPassword: 'new-password', password: 'old-password' })
+          .set('Accept', 'application/json')
+      );
 
       expect(response.statusCode).toBe(404);
     });

--- a/packages/apps/api/test/routes/users_user_id_validate.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_validate.test.ts
@@ -1,4 +1,4 @@
-import { mockedApi, withSourceIp } from './fixtures/mockedApi';
+import { mockedApi, withCallerId } from './fixtures/mockedApi';
 import { randomAlphanumeric, randomExistingUser } from './fixtures/generators';
 
 describe('/users/{userId}/validate', () => {
@@ -6,7 +6,7 @@ describe('/users/{userId}/validate', () => {
     it('validates a correct user password', async () => {
       const testUser = randomExistingUser({ password: randomAlphanumeric(10) });
       const { api } = mockedApi([testUser]);
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser.userId)(
         api.post(`/users/${testUser.userId}/validate`)
       )
         .send({ password: testUser.password })
@@ -18,7 +18,7 @@ describe('/users/{userId}/validate', () => {
     it('401s for an incorrect user password', async () => {
       const testUser = randomExistingUser();
       const { api } = mockedApi([testUser]);
-      const response = await withSourceIp(
+      const response = await withCallerId(testUser.userId)(
         api.post(`/users/${testUser.userId}/validate`)
       )
         .send({ password: 'incorrect-password' })
@@ -29,10 +29,13 @@ describe('/users/{userId}/validate', () => {
 
     it('404s for users that do not exist', async () => {
       const { api } = mockedApi();
-      const response = await api
-        .post(`/users/66666666/validate`)
-        .send({ password: 'beep-boop' })
-        .set('Accept', 'application/json');
+      const id = 1234567;
+      const response = await withCallerId(id)(
+        api
+          .post(`/users/${id}/validate`)
+          .send({ password: 'beep-boop' })
+          .set('Accept', 'application/json')
+      );
 
       expect(response.statusCode).toBe(404);
     });

--- a/smoke_tests/processorFunctions.js
+++ b/smoke_tests/processorFunctions.js
@@ -59,6 +59,16 @@ function getAuthToken(secretId, auth0Url, requestParams, callback) {
         password: password,
         client_id: clientId,
         client_secret: clientSecret,
+        scope: [
+          'openid',
+          'create:requests',
+          'delete:patron',
+          'read:user',
+          'read:requests',
+          'update:email',
+          'update:password',
+        ].join(' '),
+        audience: 'https://v1-api.stage.account.wellcomecollection.org',
       },
     };
 

--- a/smoke_tests/processorFunctions.js
+++ b/smoke_tests/processorFunctions.js
@@ -15,13 +15,13 @@ module.exports = {
 };
 
 const stageSecrets = {
-  auth0Url: 'https://wellcomecollection-stage.eu.auth0.com/oauth/token',
+  auth0Domain: 'stage.account.wellcomecollection.org',
   apiKeySecretId: 'identity/stage/account_management_system/api_key',
   credentialsSecretId: 'identity/stage/smoke_test/credentials',
 };
 
 const prodSecrets = {
-  auth0Url: 'https://wellcomecollection.eu.auth0.com/oauth/token',
+  auth0Domain: 'account.wellcomecollection.org',
   apiKeySecretId: 'identity/prod/account_management_system/api_key',
   credentialsSecretId: 'identity/prod/smoke_test/credentials',
 };
@@ -41,7 +41,7 @@ function getSecret(secretId, callback) {
 }
 
 // Implements the resource owner password OAuth flow via Auth0
-function getAuthToken(secretId, auth0Url, requestParams, callback) {
+function getAuthToken(secretId, auth0Domain, requestParams, callback) {
   const setCredentials = (credentials) => {
     const parsedCredentials = JSON.parse(credentials);
     const username = parsedCredentials['username'];
@@ -51,7 +51,7 @@ function getAuthToken(secretId, auth0Url, requestParams, callback) {
 
     const options = {
       method: 'POST',
-      url: auth0Url,
+      url: `https://${auth0Domain}/oauth/token`,
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       form: {
         grant_type: 'password',
@@ -68,7 +68,7 @@ function getAuthToken(secretId, auth0Url, requestParams, callback) {
           'update:email',
           'update:password',
         ].join(' '),
-        audience: 'https://v1-api.stage.account.wellcomecollection.org',
+        audience: `https://v1-api.${auth0Domain}`,
       },
     };
 
@@ -109,13 +109,13 @@ function addCredentials(requestParams, context, ee, next) {
 
   const thenGetAuthToken = () =>
     getAuthToken(
-      secrets['credentialsSecretId'],
-      secrets['auth0Url'],
+      secrets.credentialsSecretId,
+      secrets.auth0Domain,
       requestParams,
       next
     );
   const thenGetApiKey = () =>
-    getApiKey(secrets['apiKeySecretId'], requestParams, thenGetAuthToken);
+    getApiKey(secrets.apiKeySecretId, requestParams, thenGetAuthToken);
 
   thenGetApiKey();
 }


### PR DESCRIPTION
- Client grants for everything that uses the identity API (ie, allow applications to request tokens for the new authorizer)
- Explicit dependence of endpoints on the caller token even when the URL parameter is not `me` - this makes broken access control (where users try to access resources they don't own) less likely
- Update the smoke test to request tokens for the new authorizer - these are backward-compatible with the existing authorizer because of the presence of the `openid` scope.