### PR TITLE
Add type definitions for post-login action trigger

### DIFF
--- a/packages/apps/auth0-actions/package.json
+++ b/packages/apps/auth0-actions/package.json
@@ -8,7 +8,9 @@
     "build": "tsc --build tsconfig.build.json"
   },
   "devDependencies": {
+    "@types/auth0": "^2.34.7",
     "@types/node": "^15.12.5",
+    "@weco/auth0-client": "*",
     "typescript": "^4.5.2"
   }
 }

--- a/packages/apps/auth0-actions/src/add_custom_claims.ts
+++ b/packages/apps/auth0-actions/src/add_custom_claims.ts
@@ -1,3 +1,9 @@
-export const onExecutePostLogin = async (event: any, api: any) => {
+import { Auth0User } from '@weco/auth0-client';
+import { Event, API } from './types/post-login';
+
+export const onExecutePostLogin = async (
+  event: Event<Auth0User>,
+  api: API<Auth0User>
+) => {
   console.log('I am an action');
 };

--- a/packages/apps/auth0-actions/src/types/README.md
+++ b/packages/apps/auth0-actions/src/types/README.md
@@ -1,0 +1,7 @@
+# Actions environment type definitions
+
+While the online editor has Typescript definitions built in, these don't seem to be publicly available.
+
+We have asked about this in the Auth0 forums: https://community.auth0.com/t/public-type-definitions-availability/74480.
+
+In the mean time, each [trigger documentation page](https://auth0.com/docs/actions/triggers) contains a `Reference` section with details of the `Event` and `API` objects, which we replicate in this directory for the triggers that we're using.

--- a/packages/apps/auth0-actions/src/types/README.md
+++ b/packages/apps/auth0-actions/src/types/README.md
@@ -1,6 +1,6 @@
 # Actions environment type definitions
 
-While the online editor has Typescript definitions built in, these don't seem to be publicly available.
+While the online editor has TypeScript definitions built in, these don't seem to be publicly available.
 
 We have asked about this in the Auth0 forums: https://community.auth0.com/t/public-type-definitions-availability/74480.
 

--- a/packages/apps/auth0-actions/src/types/post-login.ts
+++ b/packages/apps/auth0-actions/src/types/post-login.ts
@@ -1,0 +1,163 @@
+import { User } from 'auth0';
+
+// https://auth0.com/docs/actions/triggers/post-login/event-object
+export type Event<UserType extends User = User> = {
+  authentication?: EventAuthentication;
+  authorization?: EventAuthorization;
+  client: EventClient;
+  connection: EventConnection;
+  organization?: EventOrganization;
+  request: EventRequest;
+  resource_server?: EventResourceServer;
+  stats: EventStats;
+  tenant: EventTenant;
+  transaction?: EventTransaction;
+  user: UserType;
+};
+
+type AuthenticationMethodName =
+  | 'federated'
+  | 'pwd'
+  | 'sms'
+  | 'email'
+  | 'mfa'
+  | 'mock';
+
+type AuthenticationMethod = {
+  name: AuthenticationMethodName;
+  timestamp: string;
+};
+
+type EventAuthentication = {
+  methods: AuthenticationMethod[];
+};
+
+type EventAuthorization = {
+  roles: string[];
+};
+
+type EventClient = {
+  client_id: string;
+  metadata: Record<string, string>;
+  name: string;
+};
+
+type EventConnection = {
+  id: string;
+  metadata?: Record<string, string>;
+  name: string;
+  strategy: string;
+};
+
+type EventOrganization = {
+  display_name: string;
+  id: string;
+  metadata: Record<string, string>;
+  name: string;
+};
+
+type GeoIP = {
+  cityName?: string;
+  continentCode?: string;
+  countryCode?: string;
+  countryCode3?: string;
+  countryName?: string;
+  latitude?: number;
+  longitude?: number;
+  timeZone?: string;
+};
+
+type EventRequest = {
+  body: Record<string, string>;
+  geoip: GeoIP;
+  hostname?: string;
+  ip: string;
+  language?: string;
+  method: string;
+  query: Record<string, string>;
+  user_agent?: string;
+};
+
+type EventResourceServer = {
+  identifier: string;
+};
+
+type EventStats = {
+  logins_count: number;
+};
+
+type EventTenant = {
+  id: string;
+};
+
+type EventTransactionProtocol =
+  | 'oidc-basic-profile'
+  | 'oidc-implicit-profile'
+  | 'oauth2-device-code'
+  | 'oauth2-resource-owner'
+  | 'oauth2-resource-owner-jwt-bearer'
+  | 'oauth2-password'
+  | 'oauth2-access-token'
+  | 'oauth2-refresh-token'
+  | 'oauth2-token-exchange'
+  | 'oidc-hybrid-profile'
+  | 'samlp'
+  | 'wsfed'
+  | 'wstrust-usernamemixed';
+
+type EventTransaction = {
+  acr_values: string[];
+  locale: string;
+  protocol?: EventTransactionProtocol;
+  requested_scopes: string[];
+  ui_locales: string[];
+};
+
+// https://auth0.com/docs/actions/triggers/post-login/api-object
+export type API<UserType extends User = User> = {
+  access: APIAccess;
+  accessToken: APIAccessToken;
+  idToken: APIIdToken;
+  multifactor: APIMultifactor;
+  user: APIUser<UserType>;
+};
+
+type APIAccess = {
+  deny: (reason: string) => API;
+};
+
+type APIAccessToken = {
+  setCustomClaim: <T>(name: string, value: T) => API;
+};
+
+type APIIdToken = {
+  setCustomClaim: <T>(name: string, value: T) => API;
+};
+
+type APIMultifactorProvider =
+  | 'any'
+  | 'duo'
+  | 'google-authenticator'
+  | 'guardian';
+
+type APIMultifactorOptions = {
+  allRememberBrowser?: boolean;
+};
+
+type APIMultifactor = {
+  enable: (
+    provider: APIMultifactorProvider,
+    options?: APIMultifactorOptions
+  ) => API;
+};
+
+type APIUser<UserType extends User = User> = {
+  setUserMetadata: <K extends keyof UserType['user_metadata']>(
+    name: K,
+    value: UserType['user_metadata'][K] | null
+  ) => API;
+  setAppMetadata: <K extends keyof UserType['app_metadata']>(
+    name: K,
+    value: UserType['app_metadata'][K] | null
+  ) => API;
+};

--- a/packages/apps/auth0-actions/tsconfig.build.json
+++ b/packages/apps/auth0-actions/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "references": [
+    {
+      "path": "../../shared/auth0-client/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/apps/auth0-actions/tsconfig.json
+++ b/packages/apps/auth0-actions/tsconfig.json
@@ -4,5 +4,10 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests"],
+  "references": [
+    {
+      "path": "../../shared/auth0-client"
+    }
+  ]
 }

--- a/packages/shared/auth0-client/package.json
+++ b/packages/shared/auth0-client/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@types/auth0": "^2.34.7",
+    "@types/jest": "^27.0.3",
     "@weco/identity-common": "*",
     "axios": "^0.21.1"
   }


### PR DESCRIPTION
While the online editor has Typescript definitions built in, these don't seem to be publicly available - I've asked about this in the Auth0 forums: https://community.auth0.com/t/public-type-definitions-availability/74480.

In the mean time, each [trigger documentation page](https://auth0.com/docs/actions/triggers) contains a `Reference` section with details of the `Event` and `API` objects, so I've just replicated those docs here but in typescript form. Bit annoying, but at least they exist now.