### PR TITLE
Make custom claims better

### DIFF
--- a/packages/apps/auth0-actions/src/add_custom_claims.ts
+++ b/packages/apps/auth0-actions/src/add_custom_claims.ts
@@ -4,15 +4,24 @@ import { Event, API } from './types/post-login';
 // Custom claims MUST be namespaced with a URL as per the OIDC spec
 // https://auth0.com/docs/security/tokens/json-web-tokens/create-namespaced-custom-claims
 const CLAIM_NAMESPACE = 'https://wellcomecollection.org';
-const BARCODE_CLAIM = `${CLAIM_NAMESPACE}/patron_barcode`;
+
+// Rather than always including our custom claims on tokens, we make them requestable
+// by a namespaced scope (ie `weco:<claim>`)
+const SCOPE_NAMESPACE = 'weco';
+
+const barcodeName = 'patron_barcode';
+const barcodeClaim = `${CLAIM_NAMESPACE}/${barcodeName}`;
+const barcodeScope = `${SCOPE_NAMESPACE}:${barcodeName}`;
+
+const hasScope = <T>(event: Event<T>, scope: string): boolean =>
+  !!event.transaction?.requested_scopes?.includes(scope);
 
 export const onExecutePostLogin = async (
   event: Event<Auth0User>,
   api: API<Auth0User>
 ) => {
   const barcode = event.user.app_metadata?.barcode;
-  if (barcode) {
-    api.accessToken.setCustomClaim(BARCODE_CLAIM, barcode);
-    api.idToken.setCustomClaim(BARCODE_CLAIM, barcode);
+  if (barcode && hasScope(event, barcodeScope)) {
+    api.idToken.setCustomClaim(barcodeClaim, barcode);
   }
 };

--- a/packages/apps/auth0-actions/src/types/post-login.ts
+++ b/packages/apps/auth0-actions/src/types/post-login.ts
@@ -15,7 +15,7 @@ export type Event<UserType extends User = User> = {
   user: UserType;
 };
 
-type AuthenticationMethodName =
+export type AuthenticationMethodName =
   | 'federated'
   | 'pwd'
   | 'sms'
@@ -23,40 +23,40 @@ type AuthenticationMethodName =
   | 'mfa'
   | 'mock';
 
-type AuthenticationMethod = {
+export type AuthenticationMethod = {
   name: AuthenticationMethodName;
   timestamp: string;
 };
 
-type EventAuthentication = {
+export type EventAuthentication = {
   methods: AuthenticationMethod[];
 };
 
-type EventAuthorization = {
+export type EventAuthorization = {
   roles: string[];
 };
 
-type EventClient = {
+export type EventClient = {
   client_id: string;
   metadata: Record<string, string>;
   name: string;
 };
 
-type EventConnection = {
+export type EventConnection = {
   id: string;
   metadata?: Record<string, string>;
   name: string;
   strategy: string;
 };
 
-type EventOrganization = {
+export type EventOrganization = {
   display_name: string;
   id: string;
   metadata: Record<string, string>;
   name: string;
 };
 
-type GeoIP = {
+export type GeoIP = {
   cityName?: string;
   continentCode?: string;
   countryCode?: string;
@@ -67,7 +67,7 @@ type GeoIP = {
   timeZone?: string;
 };
 
-type EventRequest = {
+export type EventRequest = {
   body: Record<string, string>;
   geoip: GeoIP;
   hostname?: string;
@@ -78,19 +78,19 @@ type EventRequest = {
   user_agent?: string;
 };
 
-type EventResourceServer = {
+export type EventResourceServer = {
   identifier: string;
 };
 
-type EventStats = {
+export type EventStats = {
   logins_count: number;
 };
 
-type EventTenant = {
+export type EventTenant = {
   id: string;
 };
 
-type EventTransactionProtocol =
+export type EventTransactionProtocol =
   | 'oidc-basic-profile'
   | 'oidc-implicit-profile'
   | 'oauth2-device-code'
@@ -105,7 +105,7 @@ type EventTransactionProtocol =
   | 'wsfed'
   | 'wstrust-usernamemixed';
 
-type EventTransaction = {
+export type EventTransaction = {
   acr_values: string[];
   locale: string;
   protocol?: EventTransactionProtocol;
@@ -122,36 +122,36 @@ export type API<UserType extends User = User> = {
   user: APIUser<UserType>;
 };
 
-type APIAccess = {
+export type APIAccess = {
   deny: (reason: string) => API;
 };
 
-type APIAccessToken = {
+export type APIAccessToken = {
   setCustomClaim: <T>(name: string, value: T) => API;
 };
 
-type APIIdToken = {
+export type APIIdToken = {
   setCustomClaim: <T>(name: string, value: T) => API;
 };
 
-type APIMultifactorProvider =
+export type APIMultifactorProvider =
   | 'any'
   | 'duo'
   | 'google-authenticator'
   | 'guardian';
 
-type APIMultifactorOptions = {
+export type APIMultifactorOptions = {
   allRememberBrowser?: boolean;
 };
 
-type APIMultifactor = {
+export type APIMultifactor = {
   enable: (
     provider: APIMultifactorProvider,
     options?: APIMultifactorOptions
   ) => API;
 };
 
-type APIUser<UserType extends User = User> = {
+export type APIUser<UserType extends User = User> = {
   setUserMetadata: <K extends keyof UserType['user_metadata']>(
     name: K,
     value: UserType['user_metadata'][K] | null

--- a/packages/apps/auth0-actions/tests/add_custom_claims.test.ts
+++ b/packages/apps/auth0-actions/tests/add_custom_claims.test.ts
@@ -1,5 +1,5 @@
 import { onExecutePostLogin } from '../src/add_custom_claims';
-import { API, Event } from '../src/types/post-login';
+import { API, Event, EventTransaction } from '../src/types/post-login';
 import { Auth0User } from '@weco/auth0-client';
 
 describe('add_custom_claims', () => {
@@ -7,20 +7,17 @@ describe('add_custom_claims', () => {
   const user: Auth0User = {
     app_metadata: { barcode },
   } as Auth0User;
-  const mockEvent: Event<Auth0User> = { user } as Event<Auth0User>;
+  const createEvent = (user: Auth0User, scopes: string[]): Event<Auth0User> =>
+    ({
+      user,
+      transaction: { requested_scopes: scopes } as EventTransaction,
+    } as Event<Auth0User>);
 
-  it('adds the patron barcode to the access token', () => {
-    onExecutePostLogin(mockEvent, mockPostLoginApi);
-    expect(
-      mockPostLoginApi.accessToken.setCustomClaim
-    ).toHaveBeenLastCalledWith(
-      'https://wellcomecollection.org/patron_barcode',
-      barcode
+  it('adds the patron barcode to the ID token if the barcode scope is present', () => {
+    onExecutePostLogin(
+      createEvent(user, ['weco:patron_barcode']),
+      mockPostLoginApi
     );
-  });
-
-  it('adds the patron barcode to the ID token', () => {
-    onExecutePostLogin(mockEvent, mockPostLoginApi);
     expect(mockPostLoginApi.idToken.setCustomClaim).toHaveBeenLastCalledWith(
       'https://wellcomecollection.org/patron_barcode',
       barcode
@@ -30,9 +27,16 @@ describe('add_custom_claims', () => {
   it('does not add anything if no patron barcode is present', () => {
     jest.clearAllMocks();
     onExecutePostLogin(
-      { user: { app_metadata: {} } as Auth0User } as Event<Auth0User>,
+      createEvent({ app_metadata: {} } as Auth0User, ['weco:patron_barcode']),
       mockPostLoginApi
     );
+    expect(mockPostLoginApi.accessToken.setCustomClaim).not.toBeCalled();
+    expect(mockPostLoginApi.idToken.setCustomClaim).not.toBeCalled();
+  });
+
+  it('does not add anything if the scope is not present', () => {
+    jest.clearAllMocks();
+    onExecutePostLogin(createEvent(user, []), mockPostLoginApi);
     expect(mockPostLoginApi.accessToken.setCustomClaim).not.toBeCalled();
     expect(mockPostLoginApi.idToken.setCustomClaim).not.toBeCalled();
   });


### PR DESCRIPTION
- We only really need the barcode in the ID token, so let's only put it there
- The Auth0 docs tell us that:

  > When creating your rule, make sure to set some logic that determines when to include additional claims. Injecting custom claims into every ID token that is issued is not ideal.

  This is a good point! So I've done that: to request a custom claim, you need to ask for a scope of `weco:<claim_name>`.