### PR TITLE
Tighten up session config

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -154,9 +154,18 @@ resource "auth0_client" "account_management_system" {
   app_type             = "regular_web"
   is_first_party       = true
   custom_login_page_on = true
+  oidc_conformant      = true
 
   jwt_configuration {
     alg = "RS256"
+  }
+
+  refresh_token {
+    rotation_type           = "rotating"
+    expiration_type         = "expiring"
+    token_lifetime          = local.session_absolute_lifetime_hours * local.one_hour_s
+    infinite_token_lifetime = false
+    leeway                  = 10
   }
 
   grant_types = [

--- a/infra/scoped/auth0-tenant.tf
+++ b/infra/scoped/auth0-tenant.tf
@@ -7,8 +7,8 @@ resource "auth0_tenant" "tenant" {
   # This is required for the 'password' grant type that is used when testing user credentials
   default_directory = auth0_connection.sierra.name
 
-  idle_session_lifetime = 8      // 8 hours
-  session_lifetime      = 7 * 24 // 1 week
+  idle_session_lifetime = local.session_rolling_lifetime_hours
+  session_lifetime      = local.session_absolute_lifetime_hours
 
   flags {
     enable_custom_domain_in_emails = true

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -103,6 +103,7 @@ locals {
   one_hour_s = 60 * 60
 
   // These should match the values used by the frontend app
+  // See: https://github.com/wellcomecollection/wellcomecollection.org/blob/f98e423c1ba75a703c9be07bba12c6060d55acab/identity/webapp/src/utility/auth0.ts#L80-L81
   session_absolute_lifetime_hours = 7 * 24
   session_rolling_lifetime_hours  = 8
 }

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -99,4 +99,10 @@ locals {
   # The hold limit was increased to 15 on 6 August 2021.
   # See https://wellcome.slack.com/archives/CUA669WHH/p1628089731008800
   per_user_hold_limit = 15
+
+  one_hour_s = 60 * 60
+
+  // These should match the values used by the frontend app
+  session_absolute_lifetime_hours = 7 * 24
+  session_rolling_lifetime_hours  = 8
 }


### PR DESCRIPTION
Refresh token rotation is a cool feature: https://auth0.com/docs/security/tokens/refresh-tokens/refresh-token-rotation

I've tested this by temporarily setting access token lifetimes to 10 seconds (everything still works seamlessly, which is cool)