### PR TITLE
Cache access tokens

### DIFF
--- a/packages/shared/auth0-client/package.json
+++ b/packages/shared/auth0-client/package.json
@@ -13,14 +13,14 @@
   },
   "dependencies": {
     "@weco/identity-common": "*",
-    "axios": "^0.21.1"
+    "axios": "^0.21.1",
+    "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
     "@types/auth0": "^2.34.7",
     "@types/jest": "^27.0.3",
     "@types/jsonwebtoken": "^8.5.6",
     "jest": "^27.4.3",
-    "jsonwebtoken": "^8.5.1",
     "msw": "^0.36.3",
     "ts-jest": "^27.1.1",
     "typescript": "^4.1.3"

--- a/packages/shared/identity-common/src/auth.ts
+++ b/packages/shared/identity-common/src/auth.ts
@@ -1,0 +1,40 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+type Token = {
+  accessToken: string;
+  expiresAt: number; // epoch seconds
+};
+
+// This is the leeway between when the token actually expires, and the time
+// before that after which we'll request a new token
+const tokenExpiryThreshold = 30;
+
+export const authenticatedInstanceFactory = (
+  getToken: () => Promise<Token>,
+  getInstanceConfig: () => AxiosRequestConfig = () => ({})
+) => {
+  let instance: AxiosInstance | undefined;
+  let accessToken: string | undefined;
+  let expiresAt: number = 0;
+
+  return async (): Promise<AxiosInstance> => {
+    const expiryCutoff = Math.ceil(Date.now() / 1000) + tokenExpiryThreshold;
+    const needsRefresh = Boolean(!accessToken || expiresAt <= expiryCutoff);
+    if (needsRefresh || !instance) {
+      try {
+        ({ accessToken, expiresAt } = await getToken());
+      } catch (e) {
+        console.error('Error fetching token', e);
+        throw e;
+      }
+
+      instance = axios.create({
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        ...getInstanceConfig(),
+      });
+    }
+    return instance;
+  };
+};

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -95,3 +95,5 @@ export enum ResponseStatus {
 }
 
 export type APIResponse<T> = SuccessResponse<T> | ErrorResponse;
+
+export { authenticatedInstanceFactory } from './auth';

--- a/packages/shared/identity-common/tests/auth.test.ts
+++ b/packages/shared/identity-common/tests/auth.test.ts
@@ -1,0 +1,67 @@
+import { authenticatedInstanceFactory } from '@weco/identity-common';
+
+describe('authenticatedInstanceFactory', () => {
+  it('fetches a token on its first use', async () => {
+    const testToken = 'test-access-token';
+    const getToken = jest.fn().mockResolvedValueOnce({
+      accessToken: testToken,
+      expiresAt: 3600 + Math.floor(Date.now() / 1000),
+    });
+
+    const testFactory = authenticatedInstanceFactory(getToken);
+    const instance = await testFactory();
+
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(instance.defaults.headers['Authorization']).toBe(
+      `Bearer ${testToken}`
+    );
+  });
+
+  it('does not fetch a token on subsequent uses before expiry', async () => {
+    const testToken = 'test-access-token';
+    const getToken = jest.fn().mockResolvedValueOnce({
+      accessToken: testToken,
+      expiresAt: 3600 + Math.floor(Date.now() / 1000),
+    });
+
+    const testFactory = authenticatedInstanceFactory(getToken);
+    for (let i = 0; i < 5; i++) {
+      await testFactory();
+    }
+
+    expect(getToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches a new token after expiry', async () => {
+    const testToken1 = 'test-access-token';
+    const testToken2 = 'different-test-token';
+    const expiryTime = 3600;
+
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    const getToken = jest
+      .fn()
+      .mockResolvedValueOnce({
+        accessToken: testToken1,
+        expiresAt: expiryTime + Math.floor(Date.now() / 1000),
+      })
+      .mockResolvedValueOnce({
+        accessToken: testToken2,
+        expiresAt: expiryTime + Math.floor(Date.now() / 1000),
+      });
+
+    const testFactory = authenticatedInstanceFactory(getToken);
+    const firstInstance = await testFactory();
+    jest.setSystemTime(expiryTime * 1000);
+    const secondInstance = await testFactory();
+
+    expect(getToken).toHaveBeenCalledTimes(2);
+    expect(firstInstance.defaults.headers['Authorization']).toBe(
+      `Bearer ${testToken1}`
+    );
+    expect(secondInstance.defaults.headers['Authorization']).toBe(
+      `Bearer ${testToken2}`
+    );
+    jest.useRealTimers();
+  });
+});

--- a/packages/shared/sierra-client/tests/mock-sierra-server.ts
+++ b/packages/shared/sierra-client/tests/mock-sierra-server.ts
@@ -1,9 +1,16 @@
 import crypto from 'crypto';
-import { DefaultRequestBody, rest } from 'msw';
+import { DefaultRequestBody, rest, RestRequest } from 'msw';
 import { setupServer } from 'msw/node';
 import { barcode, email, pin, recordMarc } from './test-patron';
 
-const createAccessToken = () => crypto.randomBytes(20).toString('hex');
+let accessToken: string;
+const createAccessToken = () => {
+  accessToken = crypto.randomBytes(20).toString('hex');
+  return accessToken;
+};
+
+const hasCurrentToken = (req: RestRequest): boolean =>
+  req.headers.get('Authorization') === `Bearer ${accessToken}`;
 
 export const apiRoot = 'http://sierra.test';
 
@@ -27,6 +34,9 @@ const handlers = [
   rest.post<{ patronId: string; patronSecret: string }>(
     routeUrls.credentials,
     (req, res, ctx) => {
+      if (!hasCurrentToken(req)) {
+        return res(ctx.status(401));
+      }
       if (req.body.patronId === barcode && req.body.patronSecret === pin) {
         return res(ctx.status(200));
       }
@@ -34,15 +44,24 @@ const handlers = [
     }
   ),
   rest.get(routeUrls.patron, (req, res, ctx) => {
+    if (!hasCurrentToken(req)) {
+      return res(ctx.status(401));
+    }
     return res(ctx.json(recordMarc));
   }),
   rest.put(routeUrls.patron, (req, res, ctx) => {
+    if (!hasCurrentToken(req)) {
+      return res(ctx.status(401));
+    }
     return res(ctx.status(204));
   }),
   rest.get<
     DefaultRequestBody,
     { varFieldTag?: string; varFieldContent?: string; fields: string }
   >(routeUrls.find, (req, res, ctx) => {
+    if (!hasCurrentToken(req)) {
+      return res(ctx.status(401));
+    }
     if (
       req.params.varFieldTag === 'z' &&
       req.params.varFieldContent === email


### PR DESCRIPTION
We were requesting a new access token for every request in both the Auth0 and Sierra clients - this holds onto them until they expire.