### PR TITLE
Map patron types into our own role definitions

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -218,6 +218,10 @@ resource "auth0_client" "openathens_saml_idp" {
 
   addons {
     samlp {
+      // This stops us mapping claims which we haven't explicitly provided below
+      passthrough_claims_with_no_mapping = true
+      map_unknown_claims_as_is           = false
+
       mappings = {
         user_id     = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
         email       = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -218,7 +218,6 @@ resource "auth0_client" "openathens_saml_idp" {
 
   addons {
     samlp {
-
       mappings = {
         user_id     = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
         email       = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
@@ -227,6 +226,11 @@ resource "auth0_client" "openathens_saml_idp" {
         family_name = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"
         upn         = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"
         groups      = "http://schemas.xmlsoap.org/claims/Group"
+        // The app_metadata attributes get flattened into the user object and so this maps
+        // to the 'role' property on app_metadata
+        // This uses the role claim that Microsoft define
+        // https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-saml-tokens
+        role = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
       }
       name_identifier_probes = [
         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -173,6 +173,7 @@ export function requestDelete(
     const auth0Update: APIResponse<{}> = await auth0Client.setAppMetadata(
       userId,
       {
+        ...auth0Get.result.app_metadata!,
         deleteRequested: new Date().toISOString(),
       }
     );

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -173,7 +173,8 @@ export function requestDelete(
     const auth0Update: APIResponse<{}> = await auth0Client.setAppMetadata(
       userId,
       {
-        ...auth0Get.result.app_metadata!,
+        // I believe the type assertion (!) is correct but putting the fallback here for safety
+        ...(auth0Get.result.app_metadata! || {}),
         deleteRequested: new Date().toISOString(),
       }
     );

--- a/packages/apps/api/test/routes/fixtures/mockedApi.ts
+++ b/packages/apps/api/test/routes/fixtures/mockedApi.ts
@@ -12,6 +12,7 @@ export type ExistingUser = {
   password?: string;
   markedForDeletion?: boolean;
   emailValidated?: boolean;
+  role?: string;
 };
 
 const apiGatewayHeaders = (data: object = {}) => {
@@ -51,6 +52,7 @@ export const mockedApi = (existingUsers: ExistingUser[] = []) => {
             ? new Date().toISOString()
             : undefined,
           barcode: Math.floor(Math.random() * 1e8).toString(),
+          role: user.role ?? 'Reader',
         },
       },
       user.password

--- a/packages/apps/auth0-actions/src/types/post-login.ts
+++ b/packages/apps/auth0-actions/src/types/post-login.ts
@@ -115,23 +115,23 @@ export type EventTransaction = {
 
 // https://auth0.com/docs/actions/triggers/post-login/api-object
 export type API<UserType extends User = User> = {
-  access: APIAccess;
-  accessToken: APIAccessToken;
-  idToken: APIIdToken;
-  multifactor: APIMultifactor;
+  access: APIAccess<UserType>;
+  accessToken: APIAccessToken<UserType>;
+  idToken: APIIdToken<UserType>;
+  multifactor: APIMultifactor<UserType>;
   user: APIUser<UserType>;
 };
 
-export type APIAccess = {
-  deny: (reason: string) => API;
+export type APIAccess<UserType extends User = User> = {
+  deny: (reason: string) => API<UserType>;
 };
 
-export type APIAccessToken = {
-  setCustomClaim: <T>(name: string, value: T) => API;
+export type APIAccessToken<UserType extends User = User> = {
+  setCustomClaim: <T>(name: string, value: T) => API<UserType>;
 };
 
-export type APIIdToken = {
-  setCustomClaim: <T>(name: string, value: T) => API;
+export type APIIdToken<UserType extends User = User> = {
+  setCustomClaim: <T>(name: string, value: T) => API<UserType>;
 };
 
 export type APIMultifactorProvider =
@@ -144,20 +144,20 @@ export type APIMultifactorOptions = {
   allRememberBrowser?: boolean;
 };
 
-export type APIMultifactor = {
+export type APIMultifactor<UserType extends User = User> = {
   enable: (
     provider: APIMultifactorProvider,
     options?: APIMultifactorOptions
-  ) => API;
+  ) => API<UserType>;
 };
 
 export type APIUser<UserType extends User = User> = {
   setUserMetadata: <K extends keyof UserType['user_metadata']>(
     name: K,
     value: UserType['user_metadata'][K] | null
-  ) => API;
+  ) => API<UserType>;
   setAppMetadata: <K extends keyof UserType['app_metadata']>(
     name: K,
     value: UserType['app_metadata'][K] | null
-  ) => API;
+  ) => API<UserType>;
 };

--- a/packages/apps/auth0-actions/tests/add_custom_claims.test.ts
+++ b/packages/apps/auth0-actions/tests/add_custom_claims.test.ts
@@ -5,7 +5,7 @@ import { Auth0User } from '@weco/auth0-client';
 describe('add_custom_claims', () => {
   const barcode = '1234567';
   const user: Auth0User = {
-    app_metadata: { barcode },
+    app_metadata: { barcode, role: 'Reader' },
   } as Auth0User;
   const createEvent = (user: Auth0User, scopes: string[]): Event<Auth0User> =>
     ({
@@ -59,4 +59,4 @@ const mockPostLoginApi: API<Auth0User> = {
     setUserMetadata: jest.fn(() => mockPostLoginApi),
     setAppMetadata: jest.fn(() => mockPostLoginApi),
   },
-} as API<Auth0User>;
+};

--- a/packages/apps/auth0-database-scripts/src/helpers.ts
+++ b/packages/apps/auth0-database-scripts/src/helpers.ts
@@ -10,6 +10,7 @@ export const patronRecordToUser = (patronRecord: PatronRecord): Auth0User => ({
   family_name: patronRecord.lastName,
   app_metadata: {
     barcode: patronRecord.barcode,
+    role: patronRecord.role,
   },
 });
 

--- a/packages/apps/auth0-database-scripts/tests/login.test.ts
+++ b/packages/apps/auth0-database-scripts/tests/login.test.ts
@@ -1,5 +1,5 @@
 import { errorResponse, ResponseStatus } from '@weco/identity-common';
-import { MockSierraClient } from '@weco/sierra-client';
+import { MockSierraClient, PatronRecord } from '@weco/sierra-client';
 import { User } from 'auth0';
 import login from '../src/login';
 import { patronRecordToUser } from '../src/helpers';
@@ -15,12 +15,13 @@ jest.mock('@weco/sierra-client', () => {
   };
 });
 
-const testPatronRecord = {
+const testPatronRecord: PatronRecord = {
   recordNumber: 1234567,
   barcode: '7654321',
   firstName: 'Test',
   lastName: 'Testing',
   email: 'test@test.test',
+  role: 'Reader',
 };
 
 const testPatronPassword = 'super-secret';

--- a/packages/apps/auth0-database-scripts/tests/patronRecordToUser.test.ts
+++ b/packages/apps/auth0-database-scripts/tests/patronRecordToUser.test.ts
@@ -1,11 +1,13 @@
 import { patronRecordToUser } from '../src/helpers';
+import { PatronRecord } from '@weco/sierra-client';
 
-const testPatronRecord = {
+const testPatronRecord: PatronRecord = {
   recordNumber: 1234567,
   barcode: '1234567',
   firstName: 'Test',
   lastName: 'Testing',
   email: 'test@test.test',
+  role: 'Reader',
 };
 
 describe('patronRecordToUser', () => {
@@ -19,6 +21,7 @@ describe('patronRecordToUser', () => {
       family_name: 'Testing',
       app_metadata: {
         barcode: '1234567',
+        role: 'Reader',
       },
     });
   });

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -15,6 +15,7 @@ export const auth0IdToPublic = (subjectClaim?: string): string | undefined => {
 // for the difference between these.
 export type UserMetadata = {};
 export type AppMetadata = {
+  role: string;
   barcode?: string;
   deleteRequested?: string;
 };

--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -65,7 +65,7 @@ export default class HttpSierraClient implements SierraClient {
       return instance
         .get('/patrons/' + recordNumber, {
           params: {
-            fields: 'varFields,deleted',
+            fields: 'varFields,deleted,patronType',
           },
           validateStatus: (status) => status === 200,
         })
@@ -110,7 +110,7 @@ export default class HttpSierraClient implements SierraClient {
           params: {
             varFieldTag: 'z',
             varFieldContent: email.toLowerCase(),
-            fields: 'varFields',
+            fields: 'varFields,patronType',
           },
           validateStatus: (status) => status === 200,
         })

--- a/packages/shared/sierra-client/src/MockSierraClient.ts
+++ b/packages/shared/sierra-client/src/MockSierraClient.ts
@@ -4,6 +4,7 @@ import {
   ResponseStatus,
   successResponse,
 } from '@weco/identity-common';
+import { Role } from './patron';
 
 export default class MockSierraClient implements SierraClient {
   private patrons: Map<number, PatronRecord> = new Map();
@@ -26,13 +27,15 @@ export default class MockSierraClient implements SierraClient {
 
   static randomPatronRecord = (
     firstName?: string,
-    lastName?: string
+    lastName?: string,
+    role?: Role
   ): PatronRecord => ({
     recordNumber: Math.floor(Math.random() * 1e8),
     barcode: Math.floor(Math.random() * 1e8).toString(),
     firstName: firstName ?? 'Test',
     lastName: lastName ?? 'Patron',
     email: 'test' + Math.floor(Math.random() * 100).toString() + '@patron',
+    role: role ?? 'Reader',
   });
 
   getPatronRecordByEmail = jest.fn(async (email: string) => {

--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -113,7 +113,7 @@ const patronTypeToRole = (patronType: number): Role => {
       return 'Staff';
     case 29: // Self Registered
       return 'SelfRegistered';
-    case 6:
+    case 6: // Excluded
       return 'Excluded';
     default:
       throw new Error(`Unexpected patronType: ${patronType}`);

--- a/packages/shared/sierra-client/tests/http-sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/http-sierra-client.test.ts
@@ -10,6 +10,7 @@ import {
   recordMarc,
   recordNonMarc,
   recordNumber,
+  role,
 } from './test-patron';
 import { rest } from 'msw';
 
@@ -66,6 +67,7 @@ describe('HTTP sierra client', () => {
         firstName,
         lastName,
         recordNumber,
+        role,
       });
     });
 
@@ -80,6 +82,7 @@ describe('HTTP sierra client', () => {
         firstName,
         lastName,
         recordNumber,
+        role,
       });
     });
 
@@ -131,6 +134,7 @@ describe('HTTP sierra client', () => {
         firstName,
         lastName,
         recordNumber,
+        role,
       });
     });
 
@@ -145,6 +149,7 @@ describe('HTTP sierra client', () => {
         firstName,
         lastName,
         recordNumber,
+        role,
       });
     });
 
@@ -179,6 +184,7 @@ describe('HTTP sierra client', () => {
         firstName,
         lastName,
         recordNumber,
+        role,
       });
     });
 

--- a/packages/shared/sierra-client/tests/patron.test.ts
+++ b/packages/shared/sierra-client/tests/patron.test.ts
@@ -4,6 +4,7 @@ describe('toPatronRecord', () => {
   it('creates a patron name from MARC subfields', () => {
     const recordMarc: any = {
       id: 123456,
+      patronType: 7,
       varFields: [
         {
           fieldTag: 'b',
@@ -41,6 +42,7 @@ describe('toPatronRecord', () => {
   it('strips the trailing comma from names', () => {
     const recordMarc: any = {
       id: 1101796,
+      patronType: 7,
       varFields: [
         {
           fieldTag: 'b',

--- a/packages/shared/sierra-client/tests/patron.test.ts
+++ b/packages/shared/sierra-client/tests/patron.test.ts
@@ -79,4 +79,50 @@ describe('toPatronRecord', () => {
     expect(result.firstName).toEqual('Requesting');
     expect(result.lastName).toEqual('TEST');
   });
+
+  const createRecordWithPatronType = (patronType: number) => ({
+    id: 123456,
+    patronType,
+    varFields: [
+      {
+        fieldTag: 'b',
+        content: '1234567',
+      },
+      {
+        fieldTag: 'z',
+        content: 'h.wellcome@wellcome.org',
+      },
+      {
+        fieldTag: 'n',
+        marcTag: '100',
+        ind1: ' ',
+        ind2: ' ',
+        subfields: [
+          {
+            tag: 'a',
+            content: 'Wellcome',
+          },
+          {
+            tag: 'b',
+            content: 'Henry',
+          },
+        ],
+      },
+    ],
+  });
+
+  test.each([
+    { patronType: 7, role: 'Reader' },
+    { patronType: 8, role: 'Staff' },
+    { patronType: 29, role: 'SelfRegistered' },
+    { patronType: 6, role: 'Excluded' },
+  ])('maps patronType $patronType to role $role', ({ patronType, role }) => {
+    const record = createRecordWithPatronType(patronType);
+    expect(toPatronRecord(record).role).toBe(role);
+  });
+
+  it('throws an error for unexpected patron types', () => {
+    const record = createRecordWithPatronType(15); // Inter Lib Loans
+    expect(() => toPatronRecord(record)).toThrow();
+  });
 });

--- a/packages/shared/sierra-client/tests/test-patron.ts
+++ b/packages/shared/sierra-client/tests/test-patron.ts
@@ -4,9 +4,11 @@ export const pin: string = 'superstrongpassword';
 export const firstName: string = 'Test';
 export const lastName: string = 'User';
 export const email: string = 'test.user@example.com';
+export const role: string = 'Reader';
 
 export const recordMarc: any = {
   id: 123456,
+  patronType: 7,
   varFields: [
     {
       fieldTag: 'b',
@@ -37,6 +39,7 @@ export const recordMarc: any = {
 
 export const recordNonMarc: any = {
   id: 123456,
+  patronType: 7,
   varFields: [
     {
       fieldTag: 'b',


### PR DESCRIPTION
This maps the patron types from Sierra records into our own role-ish enum. "-ish", because "SelfRegistered" isn't really a role but as per discussion with @jtweed this is a pragmatic choice for integrating with Sierra and getting done what we need to be done.

The role in question gets stuck in the `app_metadata` and mapped into the SAML claims for use by OpenAthens