### PR TITLE
Make sure always to fetch the fields required to construct a patron

### DIFF
--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -14,6 +14,8 @@ import {
   NoteOptions,
 } from './email-verification-notes';
 
+const minimumPatronFields = ['varFields', 'patronType'];
+
 export default class HttpSierraClient implements SierraClient {
   private readonly apiRoot: string;
   private readonly clientKey: string;
@@ -69,7 +71,7 @@ export default class HttpSierraClient implements SierraClient {
       return instance
         .get('/patrons/' + recordNumber, {
           params: {
-            fields: 'varFields,deleted,patronType',
+            fields: [...minimumPatronFields, 'deleted'].join(','),
           },
           validateStatus: (status) => status === 200,
         })
@@ -114,7 +116,7 @@ export default class HttpSierraClient implements SierraClient {
           params: {
             varFieldTag: 'z',
             varFieldContent: email.toLowerCase(),
-            fields: 'varFields,patronType',
+            fields: minimumPatronFields.join(','),
           },
           validateStatus: (status) => status === 200,
         })
@@ -145,7 +147,7 @@ export default class HttpSierraClient implements SierraClient {
       const currentRecordResponse = await instance.get<PatronResponse>(
         `/patrons/${recordNumber}`,
         {
-          params: { fields: 'varFields' },
+          params: { fields: minimumPatronFields.join(',') },
           validateStatus: (status) => status === 200,
         }
       );
@@ -198,7 +200,7 @@ export default class HttpSierraClient implements SierraClient {
       const currentRecordResponse = await instance.get<PatronResponse>(
         `/patrons/${recordNumber}`,
         {
-          params: { fields: 'varFields' },
+          params: { fields: minimumPatronFields.join(',') },
           validateStatus: (status) => status === 200,
         }
       );

--- a/packages/shared/sierra-client/tests/mock-sierra-server.ts
+++ b/packages/shared/sierra-client/tests/mock-sierra-server.ts
@@ -47,7 +47,14 @@ const handlers = [
     if (!hasCurrentToken(req)) {
       return res(ctx.status(401));
     }
-    return res(ctx.json(recordMarc));
+    const fields = [
+      'id',
+      ...(req.url.searchParams.get('fields')?.split(',') || []),
+    ];
+    const response = Object.fromEntries(
+      fields.map((field) => [field, recordMarc[field]])
+    );
+    return res(ctx.json(response));
   }),
   rest.put(routeUrls.patron, (req, res, ctx) => {
     if (!hasCurrentToken(req)) {

--- a/packages/shared/sierra-client/tests/test-patron.ts
+++ b/packages/shared/sierra-client/tests/test-patron.ts
@@ -9,6 +9,7 @@ export const verifiedEmail: string | undefined = undefined;
 
 export const recordMarc: any = {
   id: 123456,
+  deleted: false,
   patronType: 7,
   varFields: [
     {
@@ -41,6 +42,7 @@ export const recordMarc: any = {
 export const recordNonMarc: any = {
   id: 123456,
   patronType: 7,
+  deleted: false,
   varFields: [
     {
       fieldTag: 'b',


### PR DESCRIPTION
This also updates the mock server to respect the `fields` parameter, such that existing tests will cover this behaviour