### PR TITLE
We only need to patch the notes varfields

### DIFF
--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -168,7 +168,7 @@ export default class HttpSierraClient implements SierraClient {
           // varField with empty content. As such, passing an empty array
           // is a no-op (there's nothing to add). This is observed
           // behaviour, which is quite vaguely documented:
-          // 
+          //
           // https://techdocs.iii.com/sierraapi/Content/zObjects/requestObjectDescriptions.htm#patronPUT
           [];
 

--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -159,8 +159,17 @@ export default class HttpSierraClient implements SierraClient {
 
       const notesVarFields = verified
         ? updateVerificationNote(currentRecordResponse.data.varFields)
-        : // The way that varFields patches work in the Sierra API means
-          // that PUTting an empty array will be a no-op
+        : // The Sierra API's behaviour re varFields is non-intuitive:
+          // we pass an array of varFields that we want to _add_. These
+          // have to be x, m, or y varFields (notes, messages, images)
+          // and anything else gets ignored.
+          //
+          // If we want to remove one, we do this by passing the
+          // varField with empty content. As such, passing an empty array
+          // is a no-op (there's nothing to add). This is observed
+          // behaviour, which is quite vaguely documented:
+          // 
+          // https://techdocs.iii.com/sierraapi/Content/zObjects/requestObjectDescriptions.htm#patronPUT
           [];
 
       await instance.put(

--- a/packages/shared/sierra-client/src/email-verification-notes.ts
+++ b/packages/shared/sierra-client/src/email-verification-notes.ts
@@ -89,17 +89,6 @@ const upsertVerificationNote = (
   createVerificationNote(note, opts),
 ];
 
-const addNotesVarfields = (
-  notes: string[],
-  varFields: VarField[]
-): VarField[] => [
-  ...varFields.filter((field) => field.fieldTag !== varFieldTags.notes),
-  ...notes.map((content) => ({
-    fieldTag: varFieldTags.notes,
-    content,
-  })),
-];
-
 export const verifiedEmail = (varFields: VarField[]): string | undefined =>
   getVarFieldContent(varFields, varFieldTags.notes)
     .map(parseVerificationNote)
@@ -122,5 +111,8 @@ export const updateVerificationNote = (
     currentNotes
   );
 
-  return addNotesVarfields(updatedNotes, varFields);
+  return updatedNotes.map((note) => ({
+    fieldTag: varFieldTags.notes,
+    content: note,
+  }));
 };

--- a/packages/shared/sierra-client/tests/email-verification-notes.test.ts
+++ b/packages/shared/sierra-client/tests/email-verification-notes.test.ts
@@ -15,7 +15,7 @@ describe('email verification notes', () => {
   });
 
   describe('updateVerificationNote', () => {
-    it('updates a verification note varfield while leaving others alone', () => {
+    it('returns a list of the notes varfields including the new verification note and any other notes', () => {
       const varFields = [
         {
           fieldTag: varFieldTags.notes,
@@ -37,16 +37,12 @@ describe('email verification notes', () => {
       ];
       const result = updateVerificationNote(varFields);
 
-      expect(result).toHaveLength(4);
-      const notes = result
-        .filter(({ fieldTag }) => fieldTag === varFieldTags.notes)
-        .map(({ content }) => content);
+      expect(result).toHaveLength(2);
+      const notes = result.map(({ content }) => content);
       expect(notes).toContain(
         'Auth0: example@example.com verified by the user clicking a verification email at 2022-02-22T00:00:00.000Z'
       );
       expect(notes).toContain('Something else');
-      expect(result).toContainEqual(varFields[2]);
-      expect(result).toContainEqual(varFields[3]);
     });
 
     it('adds a new a verification note varfield if one does not exist already', () => {
@@ -61,10 +57,8 @@ describe('email verification notes', () => {
         },
       ]);
 
-      expect(result).toHaveLength(3);
-      expect(
-        result.find(({ fieldTag }) => fieldTag === varFieldTags.notes)?.content
-      ).toBe(
+      expect(result).toHaveLength(1);
+      expect(result[0]?.content).toBe(
         'Auth0: example@example.com verified by the user clicking a verification email at 2022-02-22T00:00:00.000Z'
       );
     });
@@ -80,8 +74,8 @@ describe('email verification notes', () => {
         { type: 'Implicit' }
       );
 
-      expect(result).toHaveLength(2);
-      expect(result[1].content).toBe(
+      expect(result).toHaveLength(1);
+      expect(result[0].content).toBe(
         'Auth0: example@example.com implicitly verified on initial Auth0 login with an existing Sierra account at 2022-02-22T00:00:00.000Z'
       );
     });


### PR DESCRIPTION
The way that the Sierra patron update API works is a bit odd - you pass it an array, but it's non-destructive and it only actually takes heed of notes, messages, and patron image fields. Because of this, we only actually need to patch the notes varFields: this is very convenient, because it sidesteps an issue where an existing patron image field would cause any updates to fail due to the lack of support for this feature.