### PR TITLE
Implement the deletion tracking lambda

### DIFF
--- a/infra/scoped/lambda.tf
+++ b/infra/scoped/lambda.tf
@@ -138,7 +138,7 @@ resource "aws_lambda_permission" "api" {
 
 resource "aws_lambda_function" "patron_deletion_tracker" {
   function_name = "patron-deletion-tracker-${terraform.workspace}"
-  handler       = "app.lambdaHandler"
+  handler       = "lambda.handler"
   role          = aws_iam_role.patron_deletion_tracker.arn
   runtime       = "nodejs14.x"
   timeout       = 15 * local.one_minute_s // This is the maximum

--- a/packages/apps/patron-deletion-tracker/jest.config.js
+++ b/packages/apps/patron-deletion-tracker/jest.config.js
@@ -1,0 +1,7 @@
+const base = require('../../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  name: '@weco/patron-deletion-tracker',
+  displayName: 'Patron deletion tracker',
+};

--- a/packages/apps/patron-deletion-tracker/package.json
+++ b/packages/apps/patron-deletion-tracker/package.json
@@ -11,11 +11,16 @@
   },
   "dependencies": {
     "@weco/auth0-client": "*",
-    "@weco/sierra-client": "*"
+    "@weco/sierra-client": "*",
+    "date-fns": "^2.28.0",
+    "limiter": "^2.1.0",
+    "p-queue": "6.6.2"
   },
   "devDependencies": {
+    "@sinonjs/fake-timers": "^9.1.0",
     "@types/aws-lambda": "^8.10.92",
     "@types/node": "^17.0.16",
+    "@types/sinonjs__fake-timers": "^8.1.1",
     "jest": "^27.5.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",

--- a/packages/apps/patron-deletion-tracker/src/app.ts
+++ b/packages/apps/patron-deletion-tracker/src/app.ts
@@ -1,7 +1,62 @@
 import { SierraClient } from '@weco/sierra-client';
 import { Auth0Client } from '@weco/auth0-client';
+import { ResponseStatus } from '@weco/identity-common';
+import { ScheduledHandler } from 'aws-lambda';
+import { startOfYesterday, endOfYesterday } from 'date-fns';
+import { rateLimit } from './rate-limits';
+
+const auth0RateLimited = rateLimit({
+  // See https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/management-api-endpoint-rate-limits#self-service-subscription-limits
+  rateLimits: {
+    minute: 200,
+    second: 20,
+  },
+  maxConcurrency: 5,
+});
+
+// The time before the Lambda will exit at which we should log an error that we
+// won't be able to complete the deletions
+const lambdaExitThreshold = 2000;
 
 export const createApp = (
   auth0Client: Auth0Client,
   sierraClient: SierraClient
-) => async () => {};
+): ScheduledHandler => async (event, context) => {
+  const deletedPatronsResponse = await sierraClient.getDeletedRecordNumbers({
+    start: startOfYesterday(),
+    end: endOfYesterday(),
+  });
+  if (deletedPatronsResponse.status !== ResponseStatus.Success) {
+    throw new Error(
+      'Could not fetch deleted patron record numbers: ' +
+        deletedPatronsResponse.message
+    );
+  }
+
+  const deletedRecordNumbers = deletedPatronsResponse.result;
+  console.log(`Found ${deletedRecordNumbers.length} patron records to delete`);
+
+  const remaining = new Set(deletedRecordNumbers);
+  await auth0RateLimited(
+    deletedRecordNumbers.map((recordNumber) => async () => {
+      if (context.getRemainingTimeInMillis() < lambdaExitThreshold) {
+        throw new Error(
+          `Lambda is about to exit and may not have deleted some records: ${Array.from(
+            remaining
+          ).join(', ')}`
+        );
+      }
+      await auth0Client.deleteUser(recordNumber);
+      remaining.delete(recordNumber);
+    })
+  );
+  if (remaining.size !== 0) {
+    throw new Error(
+      `Something went wrong, some records were not deleted: ${Array.from(
+        remaining
+      ).join(', ')}`
+    );
+  }
+
+  console.log('Finished deleting records');
+};

--- a/packages/apps/patron-deletion-tracker/src/app.ts
+++ b/packages/apps/patron-deletion-tracker/src/app.ts
@@ -1,5 +1,7 @@
-import { ScheduledHandler } from 'aws-lambda';
+import { SierraClient } from '@weco/sierra-client';
+import { Auth0Client } from '@weco/auth0-client';
 
-export const lambdaHandler: ScheduledHandler = async (event) => {
-  console.log('I am a Patron deletion tracker');
-};
+export const createApp = (
+  auth0Client: Auth0Client,
+  sierraClient: SierraClient
+) => async () => {};

--- a/packages/apps/patron-deletion-tracker/src/app.ts
+++ b/packages/apps/patron-deletion-tracker/src/app.ts
@@ -6,16 +6,19 @@ import { startOfYesterday, endOfYesterday } from 'date-fns';
 import { rateLimit } from './rate-limits';
 
 const auth0RateLimited = rateLimit({
-  // See https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/management-api-endpoint-rate-limits#self-service-subscription-limits
+  // See "Write Users" in the table at
+  // https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/management-api-endpoint-rate-limits#self-service-subscription-limits
   rateLimits: {
     minute: 200,
     second: 20,
   },
+  // This is set by us (not enforced by Auth0) and is fairly arbitrary
   maxConcurrency: 5,
 });
 
 // The time before the Lambda will exit at which we should log an error that we
-// won't be able to complete the deletions
+// won't be able to complete the deletions, telling us which records we might
+// have missed.
 const lambdaExitThreshold = 2000;
 
 export const createApp = (

--- a/packages/apps/patron-deletion-tracker/src/lambda.ts
+++ b/packages/apps/patron-deletion-tracker/src/lambda.ts
@@ -1,0 +1,19 @@
+import { ScheduledHandler } from 'aws-lambda';
+import { HttpSierraClient, SierraClient } from '@weco/sierra-client';
+import { Auth0Client, HttpAuth0Client } from '@weco/auth0-client';
+import { createApp } from './app';
+
+const auth0Client: Auth0Client = new HttpAuth0Client(
+  process.env.AUTH0_API_ROOT!,
+  process.env.AUTH0_API_AUDIENCE!,
+  process.env.AUTH0_CLIENT_ID!,
+  process.env.AUTH0_CLIENT_SECRET!
+);
+
+const sierraClient: SierraClient = new HttpSierraClient(
+  process.env.SIERRA_API_ROOT!,
+  process.env.SIERRA_CLIENT_KEY!,
+  process.env.SIERRA_CLIENT_SECRET!
+);
+
+export const handler: ScheduledHandler = createApp(auth0Client, sierraClient);

--- a/packages/apps/patron-deletion-tracker/src/rate-limits.ts
+++ b/packages/apps/patron-deletion-tracker/src/rate-limits.ts
@@ -1,0 +1,34 @@
+import { RateLimiter } from 'limiter';
+import PQueue from 'p-queue';
+
+type RateLimits = {
+  second: number;
+  minute: number;
+};
+
+export const rateLimit = ({
+  rateLimits,
+  maxConcurrency,
+}: {
+  rateLimits: RateLimits;
+  maxConcurrency: number;
+}) => {
+  const secondsLimiter = new RateLimiter({
+    tokensPerInterval: rateLimits.second,
+    interval: 'second',
+  });
+
+  const queue = new PQueue({
+    concurrency: maxConcurrency,
+    interval: 1000 * 60, // 1 minute
+    intervalCap: rateLimits.minute,
+  });
+
+  return <T>(calls: Array<() => Promise<T>>): Promise<T[]> =>
+    queue.addAll(
+      calls.map((call) => async () => {
+        await secondsLimiter.removeTokens(1);
+        return call();
+      })
+    );
+};

--- a/packages/apps/patron-deletion-tracker/test/app.test.ts
+++ b/packages/apps/patron-deletion-tracker/test/app.test.ts
@@ -1,0 +1,154 @@
+import { Auth0User, MockAuth0Client } from '@weco/auth0-client';
+import { MockSierraClient, PatronRecord } from '@weco/sierra-client';
+import { createApp } from '../src/app';
+import { startOfYesterday, subDays, setHours } from 'date-fns';
+import { Context, ScheduledEvent } from 'aws-lambda';
+
+const mockClients = () => ({
+  auth0: new MockAuth0Client(),
+  sierra: new MockSierraClient(),
+});
+
+const patronRecordToAuth0User = (patronRecord: PatronRecord): Auth0User => ({
+  user_id: patronRecord.recordNumber.toString(),
+  email: patronRecord.email,
+  name: patronRecord.firstName + ' ' + patronRecord.lastName,
+  given_name: patronRecord.firstName,
+  family_name: patronRecord.lastName,
+  email_verified: patronRecord.verifiedEmail === patronRecord.email,
+  app_metadata: {
+    barcode: patronRecord.barcode,
+    role: patronRecord.role,
+  },
+});
+
+describe('patron deletion tracker', () => {
+  it('deletes all patrons in Auth0 who were deleted in Sierra yesterday', async () => {
+    const { auth0, sierra } = mockClients();
+    const deletedPatrons = Array.from({ length: 10 }).map(() => {
+      const deletedPatron = MockSierraClient.randomPatronRecord();
+      sierra.addPatron(deletedPatron);
+      const deletedDate = setHours(
+        startOfYesterday(),
+        Math.floor(Math.random() * 24)
+      );
+      sierra.markDeleted(deletedPatron.recordNumber, deletedDate);
+      auth0.addUser(patronRecordToAuth0User(deletedPatron));
+      return deletedPatron;
+    });
+    const app = createApp(auth0, sierra);
+
+    await app(
+      {} as ScheduledEvent,
+      { getRemainingTimeInMillis: () => 30000 } as Context,
+      () => {}
+    );
+
+    for (const deletedPatron of deletedPatrons) {
+      expect(auth0.contains(deletedPatron.recordNumber)).toBe(false);
+    }
+  });
+
+  it('does not delete patrons who were deleted in Sierra before yesterday', async () => {
+    const { auth0, sierra } = mockClients();
+    const deletedPatron = MockSierraClient.randomPatronRecord();
+    sierra.addPatron(deletedPatron);
+    sierra.markDeleted(
+      deletedPatron.recordNumber,
+      subDays(startOfYesterday(), 1)
+    );
+    auth0.addUser(patronRecordToAuth0User(deletedPatron));
+    const app = createApp(auth0, sierra);
+
+    await app(
+      {} as ScheduledEvent,
+      { getRemainingTimeInMillis: () => 30000 } as Context,
+      () => {}
+    );
+
+    expect(auth0.contains(deletedPatron.recordNumber)).toBe(true);
+  });
+
+  it('throws an error that occurs when fetching deleted patrons', async () => {
+    const { auth0, sierra } = mockClients();
+    const errorMessage = 'test: error fetching patrons';
+    sierra.getDeletedRecordNumbers.mockRejectedValue(new Error(errorMessage));
+    const app = createApp(auth0, sierra);
+
+    await expect(
+      app(
+        {} as ScheduledEvent,
+        { getRemainingTimeInMillis: () => 30000 } as Context,
+        () => {}
+      )
+    ).rejects.toThrowError(errorMessage);
+  });
+
+  it('throws errors that occur during deletion', async () => {
+    const { auth0, sierra } = mockClients();
+    const deletedPatron = MockSierraClient.randomPatronRecord();
+    sierra.addPatron(deletedPatron);
+    sierra.markDeleted(deletedPatron.recordNumber, startOfYesterday());
+    const errorMessage = 'test: error deleting patron';
+    auth0.deleteUser.mockRejectedValue(new Error(errorMessage));
+    const app = createApp(auth0, sierra);
+
+    await expect(
+      app(
+        {} as ScheduledEvent,
+        { getRemainingTimeInMillis: () => 30000 } as Context,
+        () => {}
+      )
+    ).rejects.toThrowError(errorMessage);
+  });
+
+  it('throws an error if remaining time becomes too low while deletions are in progress', async () => {
+    const { auth0, sierra } = mockClients();
+    const patronsToDelete = Array.from({ length: 20 }).map(() => {
+      const deletedPatron = MockSierraClient.randomPatronRecord();
+      sierra.addPatron(deletedPatron);
+      const deletedDate = setHours(
+        startOfYesterday(),
+        Math.floor(Math.random() * 24)
+      );
+      sierra.markDeleted(deletedPatron.recordNumber, deletedDate);
+      auth0.addUser(patronRecordToAuth0User(deletedPatron));
+      return deletedPatron;
+    });
+    const app = createApp(auth0, sierra);
+
+    const getRemainingTimeInMillis = jest.fn();
+    for (let remainingTime = 10000; remainingTime >= 0; remainingTime -= 1000) {
+      getRemainingTimeInMillis.mockReturnValueOnce(remainingTime);
+    }
+
+    expect.hasAssertions();
+    try {
+      await app(
+        {} as ScheduledEvent,
+        ({ getRemainingTimeInMillis } as unknown) as Context,
+        () => {}
+      );
+    } catch (error) {
+      const message: string = error.message;
+      const match = message.match(
+        /Lambda is about to exit and may not have deleted some records: (?<recordsList>.+)/
+      );
+      expect(match).not.toBe(null);
+      const warnedRecords: number[] = match!
+        .groups!.recordsList!.split(', ')
+        .map(Number);
+      expect(warnedRecords).not.toHaveLength(0);
+
+      // We don't know for sure that all of the records in the warning were not deleted, because the queue might've
+      // successfully processed them while this error occurred. However - we do want to be sure that if we weren't
+      // warned about a record, it was definitely deleted.
+      const nonWarnedRecords = patronsToDelete.filter(
+        (p) => !warnedRecords.includes(p.recordNumber)
+      );
+      for (const record of nonWarnedRecords) {
+        expect(auth0.contains(record.recordNumber)).toBe(false);
+      }
+    }
+  });
+});

--- a/packages/apps/patron-deletion-tracker/test/app.test.ts
+++ b/packages/apps/patron-deletion-tracker/test/app.test.ts
@@ -122,6 +122,7 @@ describe('patron deletion tracker', () => {
       getRemainingTimeInMillis.mockReturnValueOnce(remainingTime);
     }
 
+    const errorSpy = jest.spyOn(console, 'error');
     expect.hasAssertions();
     try {
       await app(
@@ -130,9 +131,9 @@ describe('patron deletion tracker', () => {
         () => {}
       );
     } catch (error) {
-      const message: string = error.message;
+      const message: string = errorSpy.mock.calls[0][0];
       const match = message.match(
-        /Lambda is about to exit and may not have deleted some records: (?<recordsList>.+)/
+        /Some records may not have been deleted: (?<recordsList>.+)/
       );
       expect(match).not.toBe(null);
       const warnedRecords: number[] = match!

--- a/packages/apps/patron-deletion-tracker/test/deletion-tracker.test.ts
+++ b/packages/apps/patron-deletion-tracker/test/deletion-tracker.test.ts
@@ -1,5 +1,0 @@
-describe('patron deletion tracker', () => {
-  it('knows the truth', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/apps/patron-deletion-tracker/test/rate-limits.test.ts
+++ b/packages/apps/patron-deletion-tracker/test/rate-limits.test.ts
@@ -1,0 +1,132 @@
+import {
+  install as installFakeTimers,
+  InstalledClock,
+} from '@sinonjs/fake-timers';
+import { RateLimiter } from 'limiter';
+import { performance } from 'perf_hooks';
+import { rateLimit } from '../src/rate-limits';
+
+const range = (n: number) => Array.from({ length: n }).map((_, i) => i);
+
+class RateLimitedError extends Error {}
+
+// Creates a list of `n` functions which will throw a RateLimitedError if they are called above a given rate
+const rateLimitedFunctionCalls = (
+  n: number,
+  { interval, limit }: { interval: 'minute' | 'second'; limit: number },
+  implementation: () => Promise<void> = async () => {}
+): jest.Mock<Promise<number>>[] => {
+  const apiRateLimiter = new RateLimiter({
+    tokensPerInterval: limit,
+    interval,
+  });
+  return range(n).map((i) =>
+    jest.fn(async () => {
+      const success = apiRateLimiter.tryRemoveTokens(1);
+      if (success) {
+        await implementation();
+        return i;
+      } else {
+        throw new RateLimitedError();
+      }
+    })
+  );
+};
+
+// Fake timers do not override perf_hooks (used by dependencies) so we have to do that ourselves
+jest.mock('perf_hooks', () => ({
+  performance: { now: () => 0 },
+}));
+
+describe('rate limiting', () => {
+  // See https://github.com/facebook/jest/issues/11876 for why we're not using jest's fake timers
+  let clock: InstalledClock;
+  beforeAll(() => {
+    clock = installFakeTimers({ now: Date.now() });
+    performance.now = () => clock.now;
+  });
+  afterAll(() => {
+    clock.uninstall();
+  });
+
+  it('limits the per-minute rate at which functions are called', async () => {
+    const minutesRateLimit = 10;
+    const functions = rateLimitedFunctionCalls(20, {
+      interval: 'minute',
+      limit: minutesRateLimit,
+    });
+    const rateLimiter = rateLimit({
+      rateLimits: { minute: minutesRateLimit, second: minutesRateLimit },
+      maxConcurrency: 10,
+    });
+
+    const rateLimitPromise = rateLimiter(functions);
+    await clock.tickAsync('02:01');
+    const results = await rateLimitPromise;
+    expect(results).toEqual(range(20));
+  });
+
+  it('limits the per-second rate at which functions are called', async () => {
+    const secondsRateLimit = 10;
+    const functions = rateLimitedFunctionCalls(20, {
+      interval: 'second',
+      limit: secondsRateLimit,
+    });
+    const rateLimiter = rateLimit({
+      rateLimits: { minute: 61 * secondsRateLimit, second: secondsRateLimit },
+      maxConcurrency: 10,
+    });
+
+    const rateLimitPromise = rateLimiter(functions);
+    await clock.tickAsync('00:03');
+    const results = await rateLimitPromise;
+
+    expect(results).toEqual(range(20));
+  });
+
+  it('limits the concurrency of function calls', async () => {
+    const executionTime = 1;
+    const maxConcurrency = 10;
+    const secondsRateLimit = maxConcurrency + 1;
+
+    const semaphore = (() => {
+      let count = 0;
+      return {
+        count,
+        acquire: () => {
+          count++;
+          if (count > maxConcurrency) {
+            throw new Error('Max concurrency exceeded!');
+          }
+        },
+        release: () => {
+          count--;
+        },
+      };
+    })();
+    const functions = rateLimitedFunctionCalls(
+      20,
+      {
+        interval: 'second',
+        limit: secondsRateLimit,
+      },
+      async () => {
+        semaphore.acquire();
+        await new Promise((resolve) =>
+          setTimeout(resolve, 1000 * executionTime)
+        );
+        semaphore.release();
+      }
+    );
+
+    const rateLimiter = rateLimit({
+      rateLimits: { minute: 60 * secondsRateLimit, second: secondsRateLimit },
+      maxConcurrency,
+    });
+    const rateLimitPromise = rateLimiter(functions);
+    await clock.tickAsync('00:03');
+    const results = await rateLimitPromise;
+
+    expect(results).toEqual(range(20));
+  });
+});

--- a/packages/shared/sierra-client/src/MockSierraClient.ts
+++ b/packages/shared/sierra-client/src/MockSierraClient.ts
@@ -6,7 +6,6 @@ import {
   successResponse,
 } from '@weco/identity-common';
 import { Role } from './patron';
-import { recordNumber } from '../tests/test-patron';
 
 export default class MockSierraClient implements SierraClient {
   private patrons: Map<number, PatronRecord> = new Map();

--- a/packages/shared/sierra-client/src/MockSierraClient.ts
+++ b/packages/shared/sierra-client/src/MockSierraClient.ts
@@ -6,6 +6,7 @@ import {
   successResponse,
 } from '@weco/identity-common';
 import { Role } from './patron';
+import { recordNumber } from '../tests/test-patron';
 
 export default class MockSierraClient implements SierraClient {
   private patrons: Map<number, PatronRecord> = new Map();
@@ -14,6 +15,8 @@ export default class MockSierraClient implements SierraClient {
 
   get = (recordNumber: number) => this.patrons.get(recordNumber);
   getPassword = (recordNumber: number) => this.passwords.get(recordNumber);
+  markDeleted = (recordNumber: number, deletedDate: Date) =>
+    this.deletions.set(recordNumber, deletedDate);
 
   reset = () => {
     this.patrons.clear();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,6 +1429,13 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@sinonjs/fake-timers@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.0.tgz#8c92c56f195e0bed4c893ba59c8e3d55831ca0df"
+  integrity sha512-M8vapsv9qQupMdzrVzkn5rb9jG7aUTEPAZdMtME2PuBaefksFZVE2C1g4LBRTkF/k3nRDNbDc5tp5NFC1PEYxA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -1753,6 +1760,11 @@
   integrity sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==
   dependencies:
     "@types/node" "*"
+
+"@types/sinonjs__fake-timers@^8.1.1":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
+  integrity sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -3181,6 +3193,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -3601,6 +3618,11 @@ eventemitter3@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
+eventemitter3@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 events@1.1.1:
   version "1.1.1"
@@ -5561,6 +5583,11 @@ jsprim@^1.2.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
+just-performance@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/just-performance/-/just-performance-4.3.0.tgz#cc2bc8c9227f09e97b6b1df4cd0de2df7ae16db1"
+  integrity sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q==
+
 jwa@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
@@ -5659,6 +5686,13 @@ limiter@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
   integrity sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==
+
+limiter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-2.1.0.tgz#d38d7c5b63729bb84fb0c4d8594b7e955a5182a2"
+  integrity sha512-361TYz6iay6n+9KvUUImqdLuFigK+K79qrUtBsXhJTLdH4rIt/r1y8r1iozwh8KbZNpujbFTSh74mJ7bwbAMOw==
+  dependencies:
+    just-performance "4.3.0"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -6686,6 +6720,14 @@ p-pipe@^1.2.0:
   resolved "https://registry.yarnpkg.com/p-pipe/-/p-pipe-1.2.0.tgz#4b1a11399a11520a67790ee5a0c1d5881d6befe9"
   integrity sha1-SxoROZoRUgpneQ7loMHViB1r7+k=
 
+p-queue@6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
 p-queue@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-4.0.0.tgz#ed0eee8798927ed6f2c2f5f5b77fdb2061a5d346"
@@ -6697,6 +6739,13 @@ p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
   integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Most of the lines here are tests - it was a real pain to test!

**What this PR does**:
- Implements a Lambda that looks for yesterday's deleted patrons in Sierra and deletes them in Auth0
- Respects the Auth0 API's rate limiting
- Gives good warnings if something goes wrong

**What this PR doesn't do** (but future PRs will):
- Wire up the Lambda to report errors to Slack
- Look at windows other than the previous day - this will become configurable via the event. 