### PR TITLE
Be more permissive when parsing verification notes

### DIFF
--- a/packages/shared/sierra-client/src/email-verification-notes.ts
+++ b/packages/shared/sierra-client/src/email-verification-notes.ts
@@ -58,12 +58,12 @@ const parseVerificationNote = (note: string): VerificationNote | undefined => {
   }
 
   const { email, date: dateString } = match.groups;
-  const date = new Date(dateString);
+  const maybeDate = new Date(dateString);
   if (!email) {
     return undefined;
   }
 
-  return { email, date: isNaN(date.getDate()) ? undefined : date };
+  return { email, date: isNaN(maybeDate.getDate()) ? undefined : maybeDate };
 };
 
 const createVerificationNote = (

--- a/packages/shared/sierra-client/tests/email-verification-notes.test.ts
+++ b/packages/shared/sierra-client/tests/email-verification-notes.test.ts
@@ -112,6 +112,17 @@ describe('email verification notes', () => {
       ).toEqual(undefined);
     });
 
+    it('is tolerant of partially modified/malformed notes', () => {
+      expect([
+        verifiedEmail([noteField('Auth0: example@example.com verified')]),
+        verifiedEmail([
+          noteField(
+            'Auth0: example2@example.com implicitly verified Auasdfgdfgs(*^&%T(IYGUdfkjhgchgfc 2022-02-21T00:00:00.000Z'
+          ),
+        ]),
+      ]).toEqual(['example@example.com', 'example2@example.com']);
+    });
+
     it('ignores other notes and fields', () => {
       expect(
         verifiedEmail([


### PR DESCRIPTION
If we can extract meaning from them, that's good enough. The fully readable string and the date are conveniences on top of a field which fundamentally just needs to store a verified email address.