### PR TITLE
Make email templates a bit more configurable

### DIFF
--- a/universal_login/deploy.ts
+++ b/universal_login/deploy.ts
@@ -1,13 +1,9 @@
 #!/usr/bin/env ts-node-script
-
-import AWS from 'aws-sdk';
 import fs from 'fs';
-import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosInstance } from 'axios';
+import { RateLimiter } from 'limiter';
+import { getAuthenticatedInstance } from './scripts/auth0-management';
 
-const secretsManager = new AWS.SecretsManager();
-const ssm = new AWS.SSM();
-
-type Env = 'stage' | 'prod';
 type Template = 'universal-login';
 const prompts = ['login', 'reset-password', 'email-verification'] as const;
 const emails = [
@@ -20,28 +16,42 @@ const emails = [
 type Prompt = typeof prompts[number];
 type Email = typeof emails[number];
 
-const stageApiHost = 'stage.account.wellcomecollection.org';
-const prodApiHost = 'account.wellcomecollection.org';
+// For the non-production tenant the management API is limited to (in the worst case)
+// 2 req/second - this ensures we never hit that
+// https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/management-api-endpoint-rate-limits
+const rateLimiter = new RateLimiter({
+  tokensPerInterval: 2,
+  interval: 'second',
+});
 
-function getApiHost(env: Env) {
-  return env === 'stage' ? stageApiHost : prodApiHost;
-}
+const doDeploy = async () => {
+  try {
+    const env = process.argv[2] as 'stage' | 'prod';
+    console.log(`Updating environment: ${env}`);
 
-type ClientCredentials = {
-  clientId: string;
-  clientSecret: string;
-};
+    const axiosInstance = await getAuthenticatedInstance(env);
 
-// This type mirrors the data returned from Auth0
-// so does not follow camelCase conventions
-type BearerToken = {
-  // eslint-disable-next-line camelcase
-  access_token: string;
-  scope: string;
-  // eslint-disable-next-line camelcase
-  expires_in: number;
-  // eslint-disable-next-line camelcase
-  token_type: 'Bearer';
+    for (const prompt of prompts) {
+      await rateLimiter.removeTokens(1);
+      console.log(`Updating ${prompt} prompt`);
+      await updateTextPrompt(axiosInstance, prompt);
+    }
+
+    console.log(`Updating universal-login template`);
+    await rateLimiter.removeTokens(1);
+    await updateLoginPageTemplate(axiosInstance, 'universal-login');
+
+    for (const email of emails) {
+      await rateLimiter.removeTokens(1);
+      console.log(`Updating ${email} email`);
+      await updateEmail(axiosInstance, email);
+    }
+
+    console.log('Updates completed successfully');
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
 };
 
 function loadPrompt(prompt: Prompt): Record<string, unknown> {
@@ -64,164 +74,35 @@ function loadEmail(emailName: Email): Record<string, unknown> {
   return { ...emailData, body: emailTemplate };
 }
 
-async function getParameter(name: string): Promise<string> {
-  const parameterResult = await ssm
-    .getParameter({
-      Name: name,
-    })
-    .promise();
-
-  if (parameterResult.Parameter && parameterResult.Parameter.Value) {
-    return parameterResult.Parameter.Value;
-  } else {
-    throw Error(`Parameter ${name} missing!`);
-  }
-}
-
-async function getSecret<T>(path: string): Promise<T> {
-  const secret = await secretsManager
-    .getSecretValue({
-      SecretId: path,
-    })
-    .promise();
-
-  if (secret.SecretString) {
-    return JSON.parse(secret.SecretString) as T;
-  } else {
-    throw Error(`Secret ${path} missing!`);
-  }
-}
-
-async function getAuth0Hostname(env: Env) {
-  const hostnameParameterName = `identity-auth0_domain-${env}`;
-  return getParameter(hostnameParameterName);
-}
-
-async function requestApiToken(
-  hostname: string,
-  credentials: ClientCredentials
-): Promise<BearerToken> {
-  const tokenEndpoint = `https://${hostname}/oauth/token`;
-  const audience = `https://${hostname}/api/v2/`;
-
-  const tokenRequest = {
-    method: 'POST',
-    url: tokenEndpoint,
-    headers: { 'content-type': 'application/json' },
-    data: {
-      grant_type: 'client_credentials',
-      client_id: credentials.clientId,
-      client_secret: credentials.clientSecret,
-      audience: audience,
-    },
-  } as AxiosRequestConfig;
-
-  const axiosResult: AxiosResponse<BearerToken> = await axios.request(
-    tokenRequest
-  );
-
-  return axiosResult.data;
-}
-
-async function getApiToken(env: Env) {
-  const credentialsLocation = `identity/${env}/buildkite/credentials`;
-
-  const credentials = await getSecret<ClientCredentials>(credentialsLocation);
-  const hostname = await getAuth0Hostname(env);
-  const bearerToken = await requestApiToken(hostname, credentials);
-
-  return bearerToken;
-}
-
-async function updateTextPrompt(env: Env, prompt: Prompt, token: BearerToken) {
-  const apiHost = getApiHost(env);
+function updateTextPrompt(
+  instance: AxiosInstance,
+  prompt: Prompt
+): Promise<void> {
   const language = 'en';
-
   const promptData = loadPrompt(prompt);
-  const textPromptEndpoint = `https://${apiHost}/api/v2/prompts/${prompt}/custom-text/${language}`;
+  const textPromptEndpoint = `/api/v2/prompts/${prompt}/custom-text/${language}`;
 
-  const promptUpdateRequest = {
-    method: 'PUT',
-    url: textPromptEndpoint,
-    headers: {
-      authorization: `Bearer ${token.access_token}`,
-      'content-type': 'application/json',
-    },
-    data: promptData,
-  } as AxiosRequestConfig;
-
-  await axios.request(promptUpdateRequest);
+  return instance.put(textPromptEndpoint, { data: promptData });
 }
 
-async function updateLoginPageTemplate(
-  env: Env,
-  template: Template,
-  token: BearerToken
-) {
-  const apiHost = getApiHost(env);
-
+function updateLoginPageTemplate(
+  instance: AxiosInstance,
+  template: Template
+): Promise<void> {
   const templateData = loadHTMLTemplate(template);
-  const templateEndpoint = `https://${apiHost}/api/v2/branding/templates/${template}`;
+  const templateEndpoint = `/api/v2/branding/templates/${template}`;
 
-  const templateUpdateRequest = {
-    method: 'PUT',
-    url: templateEndpoint,
-    headers: {
-      authorization: `Bearer ${token.access_token}`,
-      'content-type': 'text/html',
-    },
-    data: templateData,
-  } as AxiosRequestConfig;
-
-  await axios.request(templateUpdateRequest);
+  return instance.put(templateEndpoint, { data: templateData });
 }
 
-async function updateEmail(env: Env, email: Email, token: BearerToken) {
-  const apiHost = getApiHost(env);
-
+async function updateEmail(
+  instance: AxiosInstance,
+  email: Email
+): Promise<void> {
   const emailData = loadEmail(email);
-  const emailEndpoint = `https://${apiHost}/api/v2/email-templates/${email}`;
+  const emailEndpoint = `/api/v2/email-templates/${email}`;
 
-  const templateUpdateRequest = {
-    method: 'PUT',
-    url: emailEndpoint,
-    headers: {
-      authorization: `Bearer ${token.access_token}`,
-      'content-type': 'application/json',
-    },
-    data: emailData,
-  } as AxiosRequestConfig;
-
-  await axios.request(templateUpdateRequest);
+  return instance.put(emailEndpoint, { data: emailData });
 }
 
-(async () => {
-  try {
-    const env = process.argv[2] as Env;
-    console.log(`Updating environment: ${env}`);
-
-    const token = await getApiToken(env);
-    // The non production rate limit of the API end point is 2 requests a second, this ensures we never hit the limit
-    const delay = () => new Promise((res) => setTimeout(res, 1000));
-
-    for (const prompt of prompts) {
-      await delay();
-      console.log(`Updating ${prompt} prompt`);
-      await updateTextPrompt(env, prompt, token);
-    }
-
-    console.log(`Updating universal-login template`);
-    await updateLoginPageTemplate(env, 'universal-login', token);
-
-    for (const email of emails) {
-      await delay();
-      console.log(`Updating ${email} email`);
-      await updateEmail(env, email, token);
-    }
-
-    console.log('Updates completed successfully');
-  } catch (e) {
-    console.error(e);
-    process.exit(1);
-  }
-})();
+doDeploy();

--- a/universal_login/deploy.ts
+++ b/universal_login/deploy.ts
@@ -2,7 +2,11 @@
 import fs from 'fs';
 import { AxiosInstance } from 'axios';
 import { RateLimiter } from 'limiter';
-import { Env, getAuthenticatedInstance } from './scripts/auth0-management';
+import {
+  Env,
+  environments,
+  getAuthenticatedInstance,
+} from './scripts/auth0-management';
 import { applyTemplates } from './scripts/templates';
 
 type Template = 'universal-login';
@@ -120,4 +124,9 @@ async function updateEmail(
 }
 
 const env = process.argv[2] as Env;
-doDeploy(env);
+if (environments.includes(env)) {
+  doDeploy(env);
+} else {
+  console.error('Environment must be specified as command line parameter');
+  console.error(`Must be one of: ${environments.join(', ')}`);
+}

--- a/universal_login/emails/verify_email.json
+++ b/universal_login/emails/verify_email.json
@@ -1,7 +1,7 @@
 {
   "template": "verify_email",
   "from": "Library Enquiries <library@wellcomecollection.org>",
-  "resultUrl": "https://wellcomecollection.org/account/validated",
+  "resultUrl": "https://{{site_host}}/account/validated",
   "subject": "Please verify your email address",
   "syntax": "liquid",
   "enabled": true

--- a/universal_login/package.json
+++ b/universal_login/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@types/node": "12.19.0",
     "aws-sdk": "^2.956.0",
+    "limiter": "^2.1.0",
     "ts-node": "^10.2.0",
     "typescript": "^4.1.5"
   },

--- a/universal_login/scripts/auth0-management.ts
+++ b/universal_login/scripts/auth0-management.ts
@@ -1,7 +1,8 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { getParameter, getSecret } from './aws';
 
-export type Env = 'stage' | 'prod';
+export const environments = ['stage', 'prod'] as const;
+export type Env = typeof environments[number];
 type ClientCredentials = {
   clientId: string;
   clientSecret: string;

--- a/universal_login/scripts/auth0-management.ts
+++ b/universal_login/scripts/auth0-management.ts
@@ -1,0 +1,60 @@
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { getParameter, getSecret } from './aws';
+
+type Env = 'stage' | 'prod';
+type ClientCredentials = {
+  clientId: string;
+  clientSecret: string;
+};
+
+// This type mirrors the data returned from Auth0
+// so does not follow camelCase conventions
+type BearerToken = {
+  // eslint-disable-next-line camelcase
+  access_token: string;
+  scope: string;
+  // eslint-disable-next-line camelcase
+  expires_in: number;
+  // eslint-disable-next-line camelcase
+  token_type: 'Bearer';
+};
+
+const apiHosts: Record<Env, string> = {
+  stage: 'stage.account.wellcomecollection.org',
+  prod: 'account.wellcomecollection.org',
+};
+
+export const getAuthenticatedInstance = async (
+  env: Env
+): Promise<AxiosInstance> => {
+  const credentialsLocation = `identity/${env}/buildkite/credentials`;
+  const credentials = await getSecret<ClientCredentials>(credentialsLocation);
+  const auth0Hostname = getParameter(`identity-auth0_domain-${env}`);
+
+  const tokenEndpoint = `https://${auth0Hostname}/oauth/token`;
+  const audience = `https://${auth0Hostname}/api/v2/`;
+
+  const tokenRequest = {
+    method: 'POST',
+    url: tokenEndpoint,
+    headers: { 'content-type': 'application/json' },
+    data: {
+      grant_type: 'client_credentials',
+      client_id: credentials.clientId,
+      client_secret: credentials.clientSecret,
+      audience: audience,
+    },
+  } as AxiosRequestConfig;
+
+  const axiosResult: AxiosResponse<BearerToken> = await axios.request(
+    tokenRequest
+  );
+  const token = axiosResult.data.access_token;
+
+  return axios.create({
+    baseURL: `https://${apiHosts[env]}`,
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+};

--- a/universal_login/scripts/aws.ts
+++ b/universal_login/scripts/aws.ts
@@ -1,0 +1,32 @@
+import AWS from 'aws-sdk';
+
+const secretsManager = new AWS.SecretsManager();
+const ssm = new AWS.SSM();
+
+export async function getSecret<T>(path: string): Promise<T> {
+  const secret = await secretsManager
+    .getSecretValue({
+      SecretId: path,
+    })
+    .promise();
+
+  if (secret.SecretString) {
+    return JSON.parse(secret.SecretString) as T;
+  } else {
+    throw Error(`Secret ${path} missing!`);
+  }
+}
+
+export async function getParameter(name: string): Promise<string> {
+  const parameterResult = await ssm
+    .getParameter({
+      Name: name,
+    })
+    .promise();
+
+  if (parameterResult.Parameter && parameterResult.Parameter.Value) {
+    return parameterResult.Parameter.Value;
+  } else {
+    throw Error(`Parameter ${name} missing!`);
+  }
+}

--- a/universal_login/scripts/templates.ts
+++ b/universal_login/scripts/templates.ts
@@ -1,0 +1,6 @@
+// For strings containing templates like {{key}}, this replaces that
+// template with value corresponding to the key `key` in the `data` object
+export const applyTemplates = (
+  originalString: string,
+  data: Record<string, string>
+): string => originalString.replace(/{{(.+)}}/g, (_, key) => data[key]);

--- a/universal_login/yarn.lock
+++ b/universal_login/yarn.lock
@@ -110,11 +110,6 @@ follow-redirects@^1.10.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
   integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
-  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
-
 ieee754@1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
@@ -134,6 +129,18 @@ jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+
+just-performance@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/just-performance/-/just-performance-4.3.0.tgz#cc2bc8c9227f09e97b6b1df4cd0de2df7ae16db1"
+  integrity sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q==
+
+limiter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-2.1.0.tgz#d38d7c5b63729bb84fb0c4d8594b7e955a5182a2"
+  integrity sha512-361TYz6iay6n+9KvUUImqdLuFigK+K79qrUtBsXhJTLdH4rIt/r1y8r1iozwh8KbZNpujbFTSh74mJ7bwbAMOw==
+  dependencies:
+    just-performance "4.3.0"
 
 make-error@^1.1.1:
   version "1.3.6"


### PR DESCRIPTION
Currently the staging emails had to have the same `resultUrl` as the prod emails, which was a bit of a pain - this makes them more configurable, and refactors the deploy script across a few files