### PR TITLE
Don't replace all template strings with "undefined"

### DIFF
--- a/universal_login/scripts/templates.ts
+++ b/universal_login/scripts/templates.ts
@@ -3,4 +3,10 @@
 export const applyTemplates = (
   originalString: string,
   data: Record<string, string>
-): string => originalString.replace(/{{(.+)}}/g, (_, key) => data[key]);
+): string => {
+  const templatedKeys = Object.keys(data);
+  // Only match template strings for which we have data
+  const templatedKeysRegex = templatedKeys.map((key) => `(${key})`).join('|');
+  const templateRegex = new RegExp(`{{(${templatedKeysRegex})}}`, 'g');
+  return originalString.replace(templateRegex, (_, key) => data[key]);
+};


### PR DESCRIPTION
The changes in https://github.com/wellcomecollection/identity/pull/256 were a bit over-enthusiastic and replace all template strings they saw with "undefined" - this makes that script only replace template strings that it knows