### PR TITLE
Make patron deletion windows wholly configurable

### DIFF
--- a/infra/scoped/cloudwatch.tf
+++ b/infra/scoped/cloudwatch.tf
@@ -60,6 +60,11 @@ resource "aws_cloudwatch_event_target" "patron_deletion_tracker" {
   rule      = aws_cloudwatch_event_rule.patron_deletion_tracker.name
   target_id = "patron-deletion-tracker-${terraform.workspace}"
   arn       = aws_lambda_function.patron_deletion_tracker.arn
+  input = jsonencode({
+    window = {
+      durationDays = local.deletion_tracking_window_days
+    }
+  })
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_alarm" {

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -108,4 +108,8 @@ locals {
   // See: https://github.com/wellcomecollection/wellcomecollection.org/blob/f98e423c1ba75a703c9be07bba12c6060d55acab/identity/webapp/src/utility/auth0.ts#L80-L81
   session_absolute_lifetime_hours = 7 * 24
   session_rolling_lifetime_hours  = 8
+
+  // The duration of the window in which to check for deleted Sierra patrons
+  // and remove them from Auth0 if present
+  deletion_tracking_window_days = 1
 }

--- a/packages/apps/patron-deletion-tracker/src/lambda.ts
+++ b/packages/apps/patron-deletion-tracker/src/lambda.ts
@@ -1,4 +1,3 @@
-import { ScheduledHandler } from 'aws-lambda';
 import { HttpSierraClient, SierraClient } from '@weco/sierra-client';
 import { Auth0Client, HttpAuth0Client } from '@weco/auth0-client';
 import { createApp } from './app';
@@ -16,4 +15,4 @@ const sierraClient: SierraClient = new HttpSierraClient(
   process.env.SIERRA_CLIENT_SECRET!
 );
 
-export const handler: ScheduledHandler = createApp(auth0Client, sierraClient);
+export const handler = createApp(auth0Client, sierraClient);

--- a/packages/apps/patron-deletion-tracker/src/windows.ts
+++ b/packages/apps/patron-deletion-tracker/src/windows.ts
@@ -1,0 +1,42 @@
+import {
+  addDays,
+  endOfDay,
+  endOfYesterday,
+  startOfDay,
+  startOfToday,
+  subDays,
+} from 'date-fns';
+
+// Consumers can either specify a plain `durationDays`, in which case the window
+// will cover that number of days preceding the current day, a `start` and a `durationDays`,
+// or a `start` and an `end`
+export type WindowConfig = {
+  start?: string;
+  durationDays?: number;
+  end?: string;
+};
+
+const defaultConfig = { durationDays: 1 };
+
+export const getSierraQueryOptions = (
+  config: WindowConfig = defaultConfig
+): { start: Date; end: Date } => {
+  const start = new Date(config.start ?? '');
+  const end = new Date(config.end ?? '');
+  if (config.durationDays && isNaN(start.getTime())) {
+    return {
+      start: subDays(startOfToday(), config.durationDays),
+      end: endOfYesterday(),
+    };
+  } else if (config.durationDays && !isNaN(start.getTime())) {
+    return {
+      start: startOfDay(start),
+      end: endOfDay(addDays(start, config.durationDays)),
+    };
+  } else if (!isNaN(start.getTime()) && !isNaN(end.getTime())) {
+    return { start: startOfDay(start), end: endOfDay(end) };
+  }
+  throw new Error(
+    'A window must have either a duration or a specified start and end'
+  );
+};

--- a/packages/apps/patron-deletion-tracker/test/windows.test.ts
+++ b/packages/apps/patron-deletion-tracker/test/windows.test.ts
@@ -1,0 +1,45 @@
+import { getSierraQueryOptions } from '../src/windows';
+import {
+  endOfYesterday,
+  startOfToday,
+  startOfYesterday,
+  subDays,
+} from 'date-fns';
+
+describe('getSierraQueryOptions', () => {
+  it('returns the options for the previous day by default', () => {
+    const { start, end } = getSierraQueryOptions();
+    expect(start).toEqual(startOfYesterday());
+    expect(end).toEqual(endOfYesterday());
+  });
+
+  it('returns the options for a given duration', () => {
+    const { start, end } = getSierraQueryOptions({ durationDays: 3 });
+    expect(start).toEqual(subDays(startOfToday(), 3));
+    expect(end).toEqual(endOfYesterday());
+  });
+
+  it('returns the options for a given start and duration', () => {
+    const { start, end } = getSierraQueryOptions({
+      start: '2020-01-01T00:00:00.000Z',
+      durationDays: 10,
+    });
+    expect(start).toEqual(new Date('2020-01-01T00:00:00.000Z'));
+    expect(end).toEqual(new Date('2020-01-11T23:59:59.999Z'));
+  });
+
+  it('returns the options for a given start and end string', () => {
+    const { start, end } = getSierraQueryOptions({
+      start: '2020-01-01T00:00:00.000Z',
+      end: '2020-02-01T12:12:12.121Z',
+    });
+    expect(start).toEqual(new Date('2020-01-01T00:00:00.000Z'));
+    expect(end).toEqual(new Date('2020-02-01T23:59:59.999Z'));
+  });
+
+  it('throws an error if config is insufficient', () => {
+    expect(() =>
+      getSierraQueryOptions({ end: '2020-01-01T00:00:00.000Z' })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
There is going to be a local script for triggering deletion checks over the whole window that we're interested in, but I'm waiting until I can publish https://www.npmjs.com/package/@weco/ts-aws before I implement that