### PR TITLE
Lambda error metric alarms have a naming convention

### DIFF
--- a/infra/scoped/cloudwatch.tf
+++ b/infra/scoped/cloudwatch.tf
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_event_target" "patron_deletion_tracker" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_alarm" {
-  alarm_name          = "patron-deletion-tracker-errors-${terraform.workspace}"
+  alarm_name          = "lambda-patron-deletion-tracker-${terraform.workspace}-errors"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "Errors"


### PR DESCRIPTION
See: https://github.com/wellcomecollection/platform-infrastructure/blob/a2d2ba64212a6d2f78570d73b6345b287c0517a3/monitoring/slack_alerts/lambda_errors_to_slack_alerts/src/lambda_errors_to_slack_alerts.py#L135-L139