### PR TITLE
Fix deletion tracker

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -29,6 +29,25 @@ resource "auth0_client" "dummy_test" {
   }
 }
 
+# Patron deletion tracker
+resource "auth0_client" "deletion_tracker" {
+  name                 = "Patron Deletion Tracker${local.environment_qualifier}"
+  app_type             = "non_interactive"
+  custom_login_page_on = false
+
+  grant_types = ["client_credentials"]
+}
+
+resource "auth0_client_grant" "deletion_tracker" {
+  client_id = auth0_client.deletion_tracker.id
+
+  # Management API
+  audience = "https://${aws_ssm_parameter.auth0_domain.value}/api/v2/"
+  scope = [
+    "delete:users"
+  ]
+}
+
 # API Gateway / Lambda
 # Lets the API Gateway and underlying Lambda Functions interact with the Auth0 Management API
 

--- a/infra/scoped/lambda.tf
+++ b/infra/scoped/lambda.tf
@@ -165,9 +165,9 @@ resource "aws_lambda_function" "patron_deletion_tracker" {
   environment {
     variables = {
       AUTH0_API_ROOT       = local.auth0_endpoint
-      AUTH0_API_AUDIENCE   = auth0_client_grant.api_gateway_identity.audience,
-      AUTH0_CLIENT_ID      = auth0_client.api_gateway_identity.client_id,
-      AUTH0_CLIENT_SECRET  = auth0_client.api_gateway_identity.client_secret,
+      AUTH0_API_AUDIENCE   = auth0_client_grant.deletion_tracker.audience,
+      AUTH0_CLIENT_ID      = auth0_client.deletion_tracker.client_id,
+      AUTH0_CLIENT_SECRET  = auth0_client.deletion_tracker.client_secret,
       SIERRA_API_ROOT      = aws_ssm_parameter.sierra_api_hostname.value,
       SIERRA_CLIENT_KEY    = local.sierra_api_credentials.client_key,
       SIERRA_CLIENT_SECRET = local.sierra_api_credentials.client_secret

--- a/packages/apps/patron-deletion-tracker/src/app.ts
+++ b/packages/apps/patron-deletion-tracker/src/app.ts
@@ -63,6 +63,7 @@ export const createApp = (
           );
         }
         if (!event.dryRun) {
+          console.log('Deleting ' + recordNumber);
           await auth0Client.deleteUser(recordNumber);
         } else {
           console.log(`[dry run] Deleted patron ${recordNumber}`);

--- a/packages/apps/patron-deletion-tracker/src/app.ts
+++ b/packages/apps/patron-deletion-tracker/src/app.ts
@@ -63,8 +63,10 @@ export const createApp = (
           );
         }
         if (!event.dryRun) {
-          console.log('Deleting ' + recordNumber);
-          await auth0Client.deleteUser(recordNumber);
+          const response = await auth0Client.deleteUser(recordNumber);
+          if (response.status !== ResponseStatus.Success) {
+            throw new Error('Error deleting user: ' + response.message);
+          }
         } else {
           console.log(`[dry run] Deleted patron ${recordNumber}`);
         }

--- a/packages/shared/auth0-client/src/HttpAuth0Client.ts
+++ b/packages/shared/auth0-client/src/HttpAuth0Client.ts
@@ -89,10 +89,13 @@ export default class HttpAuth0Client implements Auth0Client {
   async deleteUser(userId: number): Promise<APIResponse<void>> {
     try {
       const instance = await this.getMachineToMachineInstance();
-      await instance.delete(`/users/${SierraUserIdPrefix + userId}`, {
+      const url = `/users/${SierraUserIdPrefix + userId}`;
+      console.log('Deleting at ' + url);
+      const resp = await instance.delete(url, {
         // If the user doesn't exist, the API will still return a 204
         validateStatus: (status) => status === 204,
       });
+      console.log(resp);
       return successResponse(undefined);
     } catch (error) {
       if (error.response) {

--- a/packages/shared/auth0-client/src/HttpAuth0Client.ts
+++ b/packages/shared/auth0-client/src/HttpAuth0Client.ts
@@ -89,13 +89,10 @@ export default class HttpAuth0Client implements Auth0Client {
   async deleteUser(userId: number): Promise<APIResponse<void>> {
     try {
       const instance = await this.getMachineToMachineInstance();
-      const url = `/users/${SierraUserIdPrefix + userId}`;
-      console.log('Deleting at ' + url);
-      const resp = await instance.delete(url, {
+      await instance.delete(`/users/${SierraUserIdPrefix + userId}`, {
         // If the user doesn't exist, the API will still return a 204
         validateStatus: (status) => status === 204,
       });
-      console.log(resp);
       return successResponse(undefined);
     } catch (error) {
       if (error.response) {


### PR DESCRIPTION
Problem 1: Errors are returned by the `Auth0Client`, not thrown, so they were being swallowed.
Problem 2: The deletion tracker was using the API's client credentials, which is (a) bad practice and (b) didn't have the `delete:users` scope.