### PR TITLE
Fix/login duplicate email

### DIFF
--- a/packages/apps/auth0-database-scripts/src/get_user.ts
+++ b/packages/apps/auth0-database-scripts/src/get_user.ts
@@ -25,8 +25,8 @@ async function getUser(email: string): Promise<Auth0User | undefined> {
   } else if (patronRecordResponse.status === ResponseStatus.NotFound) {
     return undefined;
   } else if (patronRecordResponse.status === ResponseStatus.MalformedRequest) {
-    //Sierra returns status 409 for duplicate patrons, our error handling calls this a MalformedRequest
-    //here we return undefined to fail silently to progress to login where we will catch the duplicate error
+    // Sierra returns status 409 for duplicate patrons, our error handling calls this a MalformedRequest
+    // here we return undefined to fail silently to progress to login where we will catch the duplicate error
     return undefined;
   } else {
     throw new Error(patronRecordResponse.message);

--- a/packages/apps/auth0-database-scripts/src/get_user.ts
+++ b/packages/apps/auth0-database-scripts/src/get_user.ts
@@ -24,6 +24,10 @@ async function getUser(email: string): Promise<Auth0User | undefined> {
     return patronRecordToUser(patronRecord);
   } else if (patronRecordResponse.status === ResponseStatus.NotFound) {
     return undefined;
+  } else if (patronRecordResponse.status === ResponseStatus.MalformedRequest) {
+    //Sierra returns status 409 for duplicate patrons, our error handling calls this a MalformedRequest
+    //here we return undefined to fail silently to progress to login where we will catch the duplicate error
+    return undefined;
   } else {
     throw new Error(patronRecordResponse.message);
   }

--- a/packages/apps/auth0-database-scripts/src/login.ts
+++ b/packages/apps/auth0-database-scripts/src/login.ts
@@ -28,7 +28,7 @@ async function login(email: string, password: string): Promise<Auth0User> {
     throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
   }
   if (patronRecordResponse.status === ResponseStatus.MalformedRequest) {
-    throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
+    throw new WrongUsernameOrPasswordError(email, duplicateEmailCredentialMessage);
   }
   if (patronRecordResponse.status !== ResponseStatus.Success) {
     throw new Error(patronRecordResponse.message);

--- a/packages/apps/auth0-database-scripts/src/login.ts
+++ b/packages/apps/auth0-database-scripts/src/login.ts
@@ -33,7 +33,6 @@ async function login(email: string, password: string): Promise<Auth0User> {
   if (patronRecordResponse.status !== ResponseStatus.Success) {
     throw new Error(patronRecordResponse.message);
   }
-  
 
   const patronRecord = patronRecordResponse.result;
   const validationResponse = await sierraClient.validateCredentials(

--- a/packages/apps/auth0-database-scripts/src/login.ts
+++ b/packages/apps/auth0-database-scripts/src/login.ts
@@ -13,6 +13,9 @@ declare const configuration: {
 const invalidCredentialsMessage =
   "We don't recognise the email and/or password you entered. Please check your entry and try again.";
 
+const duplicateEmailCredentialMessage = 
+"There is an issue with this library account. To resolve this, please contact the library team (library@wellcomecollection.org)."
+
 async function login(email: string, password: string): Promise<Auth0User> {
   const apiRoot = configuration.API_ROOT;
   const clientKey = configuration.CLIENT_KEY;
@@ -24,9 +27,13 @@ async function login(email: string, password: string): Promise<Auth0User> {
   if (patronRecordResponse.status === ResponseStatus.NotFound) {
     throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
   }
+  if (patronRecordResponse.status === ResponseStatus.MalformedRequest) {
+    throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
+  }
   if (patronRecordResponse.status !== ResponseStatus.Success) {
     throw new Error(patronRecordResponse.message);
   }
+  
 
   const patronRecord = patronRecordResponse.result;
   const validationResponse = await sierraClient.validateCredentials(

--- a/packages/apps/auth0-database-scripts/src/login.ts
+++ b/packages/apps/auth0-database-scripts/src/login.ts
@@ -13,8 +13,8 @@ declare const configuration: {
 const invalidCredentialsMessage =
   "We don't recognise the email and/or password you entered. Please check your entry and try again.";
 
-const duplicateEmailCredentialMessage = 
-"There is an issue with this library account. To resolve this, please contact the library team (library@wellcomecollection.org)."
+const duplicateEmailCredentialMessage =
+  'There is an issue with this library account. To resolve this, please contact the library team (library@wellcomecollection.org).';
 
 async function login(email: string, password: string): Promise<Auth0User> {
   const apiRoot = configuration.API_ROOT;
@@ -28,7 +28,10 @@ async function login(email: string, password: string): Promise<Auth0User> {
     throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
   }
   if (patronRecordResponse.status === ResponseStatus.MalformedRequest) {
-    throw new WrongUsernameOrPasswordError(email, duplicateEmailCredentialMessage);
+    throw new WrongUsernameOrPasswordError(
+      email,
+      duplicateEmailCredentialMessage
+    );
   }
   if (patronRecordResponse.status !== ResponseStatus.Success) {
     throw new Error(patronRecordResponse.message);

--- a/packages/apps/auth0-database-scripts/tests/login.test.ts
+++ b/packages/apps/auth0-database-scripts/tests/login.test.ts
@@ -55,6 +55,20 @@ describe('login script', () => {
     login(testPatronRecord.email, testPatronPassword, callback);
   });
 
+  it('throws an error if Sierra returns a status 409 Malformed Request (duplicate patrons found) Error', (done) => {
+    mockSierraClient.getPatronRecordByEmail.mockResolvedValueOnce(
+      errorResponse('duplicate patrons found', ResponseStatus.MalformedRequest)
+    );
+
+    const callback = (error?: NodeJS.ErrnoException | null, data?: User) => {
+      expect(data).toBe(undefined);
+      expect(error).toBeInstanceOf(Error);
+      expect(error?.message).toBe("There is an issue with this library account. To resolve this, please contact the library team (library@wellcomecollection.org).")
+      done();
+    };
+    login(testPatronRecord.email, testPatronPassword, callback);
+  });
+
   it('throws a credentials error if Sierra credentials validation fails', (done) => {
     mockSierraClient.addPatron(testPatronRecord, testPatronPassword);
 

--- a/packages/apps/auth0-database-scripts/tests/login.test.ts
+++ b/packages/apps/auth0-database-scripts/tests/login.test.ts
@@ -63,7 +63,7 @@ describe('login script', () => {
     const callback = (error?: NodeJS.ErrnoException | null, data?: User) => {
       expect(data).toBe(undefined);
       expect(error).toBeInstanceOf(Error);
-      expect(error?.message).toBe("There is an issue with this library account. To resolve this, please contact the library team (library@wellcomecollection.org).")
+      expect(error?.message).toBe("There is an issue with this library account. To resolve this, please contact the library team (library@wellcomecollection.org).");
       done();
     };
     login(testPatronRecord.email, testPatronPassword, callback);

--- a/universal_login/prompt/login.json
+++ b/universal_login/prompt/login.json
@@ -2,6 +2,7 @@
   "login": {
     "pageTitle": "Sign in to your library account",
     "description": " ",
-    "buttonText": "Sign in"
+    "buttonText": "Sign in",
+    "custom-script-error-code": "There is an issue with this library account. To resolve this, please contact the library team (library@wellcomecollection.org)."
   }
 }


### PR DESCRIPTION
## Problem
As a user
When I enter an email address that is duplicated
I want a helpful error message so I'm clear why something has gone wrong

Ticket https://github.com/wellcomecollection/wellcomecollection.org/issues/7594

## What has changed
I have tried to allow for the Error status 409/Duplicate patron in `get_user`, then add a case for it in `login`. We handle 409 Errors with `ResponseStatus.MalformedRequest`, I have adjusted our custom `duplicateEmailCredentialMessage` to throw that error at point of login if Sierra gives us a Malformed Request at login. 

## Further context
In auth0 logs, this error appears as:
`Unhandled API response [Request failed with status code 409] (cause: [{"code":133,"specificCode":0,"httpStatus":409,"name":"Internal server error","description":"Duplicate patrons found for the specified varFieldTag`