### PR TITLE
updating the login prompt 

### DIFF
--- a/universal_login/prompt/login.json
+++ b/universal_login/prompt/login.json
@@ -2,6 +2,7 @@
   "login": {
     "pageTitle": "Sign in to your library account",
     "description": " ",
-    "buttonText": "Sign in"
+    "buttonText": "Sign in",
+    "custom-script-error-code": "There is an issue with this library account. To resolve this, please contact Library Enquiries (library@wellcomecollection.org)."
   }
 }


### PR DESCRIPTION
We want to update the wording from 'Something went wrong, please try again later' to be more in line with our default wording to contact library enquiries. 

![Screenshot 2022-03-22 at 11 48 22](https://user-images.githubusercontent.com/16557524/159475237-48811ed7-a9c3-4d30-8f5f-1bc5fa0c2c12.png)


This PR doesn't approach the point of styling raised by the original ticket here https://github.com/wellcomecollection/wellcomecollection.org/issues/7594

There are two reasons for this: 

- In order to change styling we would need to have a custom error message, much like I was trying to achieve in [this PR](https://github.com/wellcomecollection/identity/pull/275). Having logic to raise a specific message each time we came up with a duplicate error in `get_user` and `login` will also mean we need to cover that use case across change password, update email etc. There is more detail in [the closed PR](https://github.com/wellcomecollection/identity/pull/276), the upshot is, it is a lot of work to account for this error across each state (login, change email etc) just to show a default message. 

- We are in limited in the css styling options we can implement for the default error. We also cannot change where this error appears, as the error itself will appear when username and password is entered, the error should appear over the email and password boxes in the UI. If the error only impacted the email address, it should appear in line with the email - but this won't be the case as we won't be able to progress through login without entering both and email and password. 

