### PR TITLE
Minimise errors relating to change/reset password 

### DIFF
--- a/universal_login/prompt/reset-password.json
+++ b/universal_login/prompt/reset-password.json
@@ -2,7 +2,8 @@
   "reset-password": {
     "pageTitle": "Reset password",
     "passwordPlaceholder": "Create new password",
-    "description": "To protect your account, make sure your password contains: One lowercase character, one uppercase character, one number, 8 characters minimum."
+    "description": "To protect your account, make sure your password contains: One lowercase character, one uppercase character, one number, 8 characters minimum. Repeating characters, such as aaaa, ababab, abcabc, won't be accepted as a password",
+    "custom-script-error-code": "There is an issue with this library account. To resolve this, please contact Library Enquiries (library@wellcomecollection.org)."
   },
   "reset-password-request": {
     "pageTitle": "Forgotten password",

--- a/universal_login/prompt/reset-password.json
+++ b/universal_login/prompt/reset-password.json
@@ -2,7 +2,7 @@
   "reset-password": {
     "pageTitle": "Reset password",
     "passwordPlaceholder": "Create new password",
-    "description": "To protect your account, make sure your password contains: One lowercase character, one uppercase character, one number, 8 characters minimum. Repeating characters, such as aaaa, ababab, abcabc, won't be accepted as a password",
+    "description": "To protect your account, make sure your password contains: One lowercase character, one uppercase character, one number, 8 characters minimum. Repeating characters, such as aaaa, ababab, abcabc, won't be accepted as a password.",
     "custom-script-error-code": "There is an issue with this library account. To resolve this, please contact Library Enquiries (library@wellcomecollection.org)."
   },
   "reset-password-request": {

--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -227,7 +227,13 @@
     </div>
     <div class="container">
       <div class="container-inner">
+        <!-- Here we need to show the description message -->
         <h1>{{ prompt.screen.texts.pageTitle }}</h1>
+        {% if prompt.name == "reset-password" %}
+        <p>
+          <strong>Note:</strong> Repeating characters, such as aaaa, ababab, abcabc, won't be accepted as a password.
+        </p>
+        {% endif %}
         {% if prompt.name == "login" %}
         <p>
           <strong>Note:</strong> Please use the email address connected to your

--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -231,10 +231,10 @@
         <h1>{{ prompt.screen.texts.pageTitle }}</h1>
         {% if prompt.name == "reset-password" %}
         <p>
-          <strong>Note:</strong> Repeating characters, such as aaaa, ababab, abcabc, won't be accepted as a password.
+          <strong>Note:</strong> Repeating characters, such as aaaa, ababab,
+          abcabc, won't be accepted as a password.
         </p>
-        {% endif %}
-        {% if prompt.name == "login" %}
+        {% endif %} {% if prompt.name == "login" %}
         <p>
           <strong>Note:</strong> Please use the email address connected to your
           library account to sign in. You'll no longer be able to use your


### PR DESCRIPTION
### Why?
We've noticed a small amount of errors whereby Sierra rejects a changed/reset password and shows a generic 'something went wrong' error to the user.
This is because Sierra has rules about 'trivial patterns' in password. 
Ticket: https://github.com/wellcomecollection/wellcomecollection.org/issues/7816

In this case, 'trivial patterns' are specifically repeated characters e.g. aaaa, ababab, abcabc. If you try to reset/change your password using your library account and you enter a new password with repeated characters and submit the form by clicking 'Update password', you'll get this message: 

![Change password pop up with 'Unknown error' on red alert box](https://user-images.githubusercontent.com/16557524/160553414-227e3d24-c63c-432c-938a-0521881b8a1c.png)

We want to improve this. We have restrictions on what we can improve as we don't have much control over the appearance of error messaging in the login/reset/change password flow. 

### What does this PR do?
It updates default error on reset password page - so we guide people to contact library staff if an error occurs. This PR also update text on universal-login that appears conditionally at reset/change flow to include wording on avoiding repeated characters.

Ideally this messaging would be built into the password policy (illustrated in the user experience by the check boxes turning green as your password passes each password policy step ✅ ), but we have [reasons](https://wellcome.slack.com/archives/CUA669WHH/p1648540650031559) for not doing this yet.

On reset/change that updated note should appear like this:
![Change password pop up with note on avoiding repeated characters](https://user-images.githubusercontent.com/16557524/160553605-0e5b6fd6-2a8e-473f-b639-ee96465843a9.png)

