### PR TITLE
Explain what's broken if you terraform without a workspace

### DIFF
--- a/infra/scoped/run_terraform.sh
+++ b/infra/scoped/run_terraform.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+
 TERRAFORM_WORKSPACE=$(terraform workspace show)
+
+# If you don't select a workspace, the commands further down will fail
+# with non-obvious errors about non-existent Parameters and Secrets.
+if [[ "$TERRAFORM_WORKSPACE" != "stage" ]] && [[ "$TERRAFORM_WORKSPACE" != "prod" ]]
+then
+  echo "You must select a workspace before continuing, e.g. 'terraform workspace select stage'"
+  exit 1
+fi
 
 AWS_CLI_PROFILE="identity-terraform"
 IDENTITY_DEVELOPER_ARN="arn:aws:iam::770700576653:role/identity-developer"


### PR DESCRIPTION
I did a fresh checkout, and if you try to run Terraform straight away you get a non-obvious error:

```console
$ top
An error occurred (ParameterNotFound) when calling the GetParameter operation:

An error occurred (ParameterNotFound) when calling the GetParameter operation:

An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret.
provider.auth0.domain
  Enter a value: ^C
```

This is because `terraform workspace show` returns `default`, but we don't have SSM parameters for a default environment.

Now the Terraform wrapper script prompts you to select a workspace if it's not one it recognises:

```console
$ tfp
You must select a workspace before continuing, e.g. 'terraform workspace select stage'
```