### PR TITLE
Add the catalogue API root config for the requests API

### DIFF
--- a/infra/scoped/ecs_services.tf
+++ b/infra/scoped/ecs_services.tf
@@ -36,6 +36,8 @@ module "requests" {
     apm_service_name  = "requests-api"
     apm_environment   = terraform.workspace
     user_hold_limit   = local.per_user_hold_limit
+
+    catalogue_api_public_root = local.catalogue_api_public_root
   }
   secrets = merge(local.es_secrets, local.apm_secret_config, {
     sierra_api_key    = "sierra-api-credentials-${terraform.workspace}:SierraAPIKey"

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -53,6 +53,13 @@ locals {
   }
   wellcome_collection_site_uri = "https://${local.wellcome_collection_hostnames[terraform.workspace]}"
 
+  # Catalogue API
+  catalogue_api_hostnames = {
+    stage = "api-stage.wellcomecollection.org"
+    prod  = "api.wellcomecollection.org"
+  }
+  catalogue_api_public_root = "https://${local.catalogue_api_hostnames[terraform.workspace]}/catalogue/v2"
+
   # Account Management System
   ams_context_path         = "account"
   ams_redirect_uri         = "${local.wellcome_collection_site_uri}/${local.ams_context_path}/api/auth/callback"


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5481 – this is (part of) why the catalogue API deployment is failing in staging; the requests API doesn't know how to find the catalogue API. 😢 

This just adds the new config parameter, and I've only deployed it to stage so far. Once I've seen it up and working, I'll deploy it to prod.

I'll remove the old Elasticsearch config in a separate PR, once we know everything is working and we know we won't be rolling back.