### PR TITLE
Update custom claims to support roles

### DIFF
--- a/packages/apps/auth0-actions/src/add_custom_claims.ts
+++ b/packages/apps/auth0-actions/src/add_custom_claims.ts
@@ -13,6 +13,10 @@ const barcodeName = 'patron_barcode';
 const barcodeClaim = `${CLAIM_NAMESPACE}/${barcodeName}`;
 const barcodeScope = `${SCOPE_NAMESPACE}:${barcodeName}`;
 
+const roleName = 'patron_role';
+const roleClaim = `${CLAIM_NAMESPACE}/${roleName}`;
+const roleScope = `${SCOPE_NAMESPACE}:${roleName}`;
+
 const hasScope = <T>(event: Event<T>, scope: string): boolean =>
   !!event.transaction?.requested_scopes?.includes(scope);
 
@@ -23,5 +27,10 @@ export const onExecutePostLogin = async (
   const barcode = event.user.app_metadata?.barcode;
   if (barcode && hasScope(event, barcodeScope)) {
     api.idToken.setCustomClaim(barcodeClaim, barcode);
+  }
+
+  const role = event.user.app_metadata?.role;
+  if (role && hasScope(event, roleScope)) {
+    api.idToken.setCustomClaim(roleClaim, role);
   }
 };

--- a/packages/apps/auth0-actions/tests/add_custom_claims.test.ts
+++ b/packages/apps/auth0-actions/tests/add_custom_claims.test.ts
@@ -71,7 +71,6 @@ describe('add_custom_claims', () => {
     );
   });
 
-
   it('does not add anything if the scope is not present', () => {
     jest.clearAllMocks();
     onExecutePostLogin(createEvent(user, []), mockPostLoginApi);

--- a/packages/apps/auth0-actions/tests/add_custom_claims.test.ts
+++ b/packages/apps/auth0-actions/tests/add_custom_claims.test.ts
@@ -4,8 +4,9 @@ import { Auth0User } from '@weco/auth0-client';
 
 describe('add_custom_claims', () => {
   const barcode = '1234567';
+  const role = 'Reader';
   const user: Auth0User = {
-    app_metadata: { barcode, role: 'Reader' },
+    app_metadata: { barcode, role },
   } as Auth0User;
   const createEvent = (user: Auth0User, scopes: string[]): Event<Auth0User> =>
     ({
@@ -33,6 +34,43 @@ describe('add_custom_claims', () => {
     expect(mockPostLoginApi.accessToken.setCustomClaim).not.toBeCalled();
     expect(mockPostLoginApi.idToken.setCustomClaim).not.toBeCalled();
   });
+
+  it('adds the patron role to the ID token if the role scope is present', () => {
+    onExecutePostLogin(
+      createEvent(user, ['weco:patron_role']),
+      mockPostLoginApi
+    );
+    expect(mockPostLoginApi.idToken.setCustomClaim).toHaveBeenLastCalledWith(
+      'https://wellcomecollection.org/patron_role',
+      role
+    );
+  });
+
+  it('does not add anything if no patron role is present', () => {
+    jest.clearAllMocks();
+    onExecutePostLogin(
+      createEvent({ app_metadata: {} } as Auth0User, ['weco:patron_role']),
+      mockPostLoginApi
+    );
+    expect(mockPostLoginApi.accessToken.setCustomClaim).not.toBeCalled();
+    expect(mockPostLoginApi.idToken.setCustomClaim).not.toBeCalled();
+  });
+
+  it('adds the patron role and barcode to the ID token if boths scopes are present', () => {
+    onExecutePostLogin(
+      createEvent(user, ['weco:patron_role', 'weco:patron_barcode']),
+      mockPostLoginApi
+    );
+    expect(mockPostLoginApi.idToken.setCustomClaim).toHaveBeenCalledWith(
+      'https://wellcomecollection.org/patron_role',
+      role
+    );
+    expect(mockPostLoginApi.idToken.setCustomClaim).toHaveBeenCalledWith(
+      'https://wellcomecollection.org/patron_barcode',
+      barcode
+    );
+  });
+
 
   it('does not add anything if the scope is not present', () => {
     jest.clearAllMocks();


### PR DESCRIPTION
Scope `weco:patron_role` returns `https://wellcomecollection.org/patron_role` containing roles, if present.