### PR TITLE
Create updateUserAfterRegistration endpoint

### DIFF
--- a/infra/scoped/auth0-resource-server.tf
+++ b/infra/scoped/auth0-resource-server.tf
@@ -39,6 +39,11 @@ resource "auth0_resource_server" "identity_api" {
     description = "Update password"
   }
 
+  scopes {
+    value       = "update:user"
+    description = "Update user info"
+  }
+
   // Applications are allowed refresh tokens
   allow_offline_access                            = true
   token_lifetime                                  = 60 * 60 // 1 hour

--- a/packages/apps/api-authorizer/src/handler.ts
+++ b/packages/apps/api-authorizer/src/handler.ts
@@ -40,6 +40,9 @@ const validateRequest = resourceAuthorizationValidator({
     POST: allOf(isSelf, hasScopes('create:requests')),
     GET: allOf(isSelf, hasScopes('read:requests')),
   },
+  '/users/{userId}/registration': {
+    PUT: allOf(isSelf, hasScopes('update:user')),
+  },
 });
 
 export const createLambdaHandler = (validateToken: TokenValidator) => async (

--- a/packages/apps/api/src/app.ts
+++ b/packages/apps/api/src/app.ts
@@ -40,6 +40,9 @@ export function createApplication(clients: Clients): Application {
   return app;
 }
 
+// The handler for this endpoint duplicates a lot of the work in the handler for
+// `/users/:user_id` This is deliberate as 1. they may diverge and 2. we can do
+//  a check that the user is at the correct stage of the signup process here
 function registerUsersUserIdRegistrationResource(
   clients: Clients,
   app: Application

--- a/packages/apps/api/src/app.ts
+++ b/packages/apps/api/src/app.ts
@@ -9,6 +9,7 @@ import {
   getUser,
   requestDelete,
   updateUser,
+  updateUserAfterRegistration,
   validatePassword,
 } from './handlers/user';
 import { errorHandler } from './handlers/errorHandler';
@@ -27,6 +28,7 @@ export function createApplication(clients: Clients): Application {
   app.use(awsServerlessExpressMiddleware.eventContext());
 
   [
+    registerUsersUserIdRegistrationResource,
     registerUsersUserIdResource,
     registerUsersUserIdPasswordResource,
     registerUsersUserIdDeletionRequestResource,
@@ -36,6 +38,23 @@ export function createApplication(clients: Clients): Application {
   app.use(errorHandler);
 
   return app;
+}
+
+function registerUsersUserIdRegistrationResource(
+  clients: Clients,
+  app: Application
+): void {
+  const corsOptions = cors({
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-API-Key'],
+    methods: 'OPTIONS,PUT',
+    origin: process.env.API_ALLOWED_ORIGINS,
+  });
+  app.options('/users/:user_id/registration', corsOptions);
+  app.put(
+    '/users/:user_id/registration',
+    corsOptions,
+    asyncHandler(updateUserAfterRegistration(clients.auth0))
+  );
 }
 
 function registerUsersUserIdResource(clients: Clients, app: Application): void {

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -48,6 +48,34 @@ export function getUser(auth0Client: Auth0Client) {
   };
 }
 
+export function updateUserAfterRegistration(auth0Client: Auth0Client) {
+  return async function (request: Request, response: Response): Promise<void> {
+    const userId: number = getTargetUserId(request);
+    const firstName: string = request.body.firstName;
+    const lastName: string = request.body.lastName;
+
+    const auth0UserIdGet: APIResponse<Auth0User> = await auth0Client.getUserByUserId(
+      userId
+    );
+    if (auth0UserIdGet.status !== ResponseStatus.Success) {
+      throw clientResponseToHttpError(auth0UserIdGet);
+    }
+    const auth0Profile: Auth0User = auth0UserIdGet.result;
+
+    const auth0Update: APIResponse<Auth0User> = await auth0Client.updateUser(
+      userId,
+      auth0Profile.email
+    );
+    if (auth0Update.status !== ResponseStatus.Success) {
+      throw clientResponseToHttpError(auth0Update);
+    }
+
+    // TODO: create patron record in Sierra
+
+    response.status(200).json(toUser(auth0Update.result));
+  };
+}
+
 export function updateUser(auth0Client: Auth0Client) {
   const checkPassword = passwordCheckerForUser(auth0Client);
   return async function (request: Request, response: Response): Promise<void> {


### PR DESCRIPTION
Part of wellcomecollection/wellcomecollection.org#7808

Opted to create a new endpoint and handler instead of wrapping `updateUser` in conditionals based on whether we've got a password or not.

I think the `user_id` we're going to pass from the NextJS app will be prefixed with `auth0|` and I imagine we'll need to strip this off in order for the [`getTargetUserId` function](https://github.com/wellcomecollection/identity/blob/main/packages/apps/api/src/handlers/user.ts#L217-L238) not to blow up. I've seen elsewhere we're checking [if it starts with `auth0|p`](https://github.com/wellcomecollection/identity/blob/main/packages/shared/auth0-client/src/auth0.ts#L4) – I'm not sure where that `p` comes from (and it doesn't appear in the ids that I've been testing with)

__Edit:__ [I've removed the `auth0|` (and maybe `p`) before it gets this far](https://github.com/wellcomecollection/wellcomecollection.org/pull/7944/files#diff-5785a90503c26d63f092dff4b182b0f28a4a7375107aaddbfc9007997b2cd6fcR30-R31). I guess the `p` is for 'patron', although I wasn't sure if it would be added to newly created Sierra-database records using Auth0 as a way to signup, so left it optional for now. If we know the prefix either definitely will or will not contain a `p`, we can remove the `?` or the `p` from the regex, respectively.