### PR TITLE
update action to check only for user first and last name 

### DIFF
--- a/packages/apps/auth0-actions/src/redirect_to_full_registration.ts
+++ b/packages/apps/auth0-actions/src/redirect_to_full_registration.ts
@@ -6,14 +6,12 @@ export const onExecutePostLogin = async (
   api: API<Auth0User>
 ) => {
   const REGISTRATION_FORM_URL: string = event.secrets.IDENTITY_APP_BASEURL;
-  // If the user has accepted the terms, and we have their first and last name already, we don't need
-  // to do anything else so bail out here
-  if (
-    event.user.app_metadata?.terms_and_conditions_accepted &&
-    Boolean(event.user.given_name) &&
-    Boolean(event.user.family_name)
-  )
+  // If we have the user's first and last name already, we don't need to do anything else so bail out here
+  // TODO: It would be good to improve this further by checking for app_metadata.terms_and_conditions_accepted here
+
+  if (Boolean(event.user.given_name) && Boolean(event.user.family_name)) {
     return;
+  }
 
   // We send the user straight to the full registration form after they first register email and password
   // Full registration form has three fields aka formData: firstname, lastname and terms_and_conditions_accepted

--- a/packages/apps/auth0-actions/tests/redirect_to_full_registration.test.ts
+++ b/packages/apps/auth0-actions/tests/redirect_to_full_registration.test.ts
@@ -16,7 +16,7 @@ import { Auth0User } from '@weco/auth0-client';
 
 describe('redirect_to_full_registration', () => {
   const user: Auth0User = {
-    app_metadata: { terms_and_conditions_accepted: false },
+    app_metadata: {},
   } as Auth0User;
 
   const createEvent = (user: Auth0User): Event<Auth0User> =>
@@ -27,11 +27,16 @@ describe('redirect_to_full_registration', () => {
     expect(mockPostLoginApi.redirect.sendUserTo).not.toBeCalled();
   });
 
-  it('redirects the user if terms_and_conditions_accepted is true and firstname, surname is present', () => {
+  it('redirects if the user firstname, surname is not present', () => {
     jest.clearAllMocks();
     const auth0SecretsObject = {
       IDENTITY_APP_BASEURL: 'stage.wellcomecollection.org',
       AUTH0_PAYLOAD_SECRET: 'ABCDEFG1234',
+    };
+    const newUser: Auth0User = {
+      user_id: 'p|12345',
+      email: 'raviravioli@pastatimes.com',
+      app_metadata: { role: '' },
     };
 
     const event = {
@@ -48,14 +53,6 @@ describe('redirect_to_full_registration', () => {
         request: { hostname: 'stage.wellcomecollection.org' } as EventRequest,
         secrets: auth0SecretsObject as EventSecrets,
       } as Event<Auth0User>);
-
-    const newUser: Auth0User = {
-      user_id: 'p|12345',
-      given_name: 'Ravi',
-      family_name: 'Ravioli',
-      email: 'raviravioli@pastatimes.com',
-      app_metadata: { terms_and_conditions_accepted: false, role: '' },
-    };
 
     const REGISTRATION_FORM_URL = event.secrets.IDENTITY_APP_BASEURL;
 


### PR DESCRIPTION
We were trying to check for appMetadata terms_and_conditions_accepted value as well as first and last name previously, if all these were present we returned i.e. skipped this redirect action. 

On testing with a current user, this if statement check was not working as expected and instead would keep trying to redirect. I've added a TODO to come back and improve the conditional, but for now to allow for current users who encounter this action after logging in, i've adjusted to check only for first and last name. 

