### PR TITLE
use createPatron in updateUserAfterRegistration

### DIFF
--- a/infra/scoped/lambda.tf
+++ b/infra/scoped/lambda.tf
@@ -90,18 +90,21 @@ resource "aws_lambda_function" "api" {
 
   environment {
     variables = {
-      AUTH0_API_ROOT      = local.auth0_endpoint
-      AUTH0_API_AUDIENCE  = auth0_client_grant.api_gateway_identity.audience,
-      AUTH0_CLIENT_ID     = auth0_client.api_gateway_identity.client_id,
-      AUTH0_CLIENT_SECRET = auth0_client.api_gateway_identity.client_secret,
-      API_ALLOWED_ORIGINS = local.identity_v1_docs_endpoint,
-      EMAIL_SMTP_HOSTNAME = local.email_credentials["smtp_hostname"],
-      EMAIL_SMTP_PORT     = local.email_credentials["smtp_port"],
-      EMAIL_SMTP_USERNAME = local.email_credentials["smtp_username"],
-      EMAIL_SMTP_PASSWORD = local.email_credentials["smtp_password"],
-      EMAIL_FROM_ADDRESS  = local.email_noreply_name_and_address,
-      EMAIL_ADMIN_ADDRESS = aws_ssm_parameter.email_admin_address.value,
-      SUPPORT_URL         = aws_ssm_parameter.auth0_support_url.value
+      AUTH0_API_ROOT       = local.auth0_endpoint
+      AUTH0_API_AUDIENCE   = auth0_client_grant.api_gateway_identity.audience,
+      AUTH0_CLIENT_ID      = auth0_client.api_gateway_identity.client_id,
+      AUTH0_CLIENT_SECRET  = auth0_client.api_gateway_identity.client_secret,
+      API_ALLOWED_ORIGINS  = local.identity_v1_docs_endpoint,
+      EMAIL_SMTP_HOSTNAME  = local.email_credentials["smtp_hostname"],
+      EMAIL_SMTP_PORT      = local.email_credentials["smtp_port"],
+      EMAIL_SMTP_USERNAME  = local.email_credentials["smtp_username"],
+      EMAIL_SMTP_PASSWORD  = local.email_credentials["smtp_password"],
+      EMAIL_FROM_ADDRESS   = local.email_noreply_name_and_address,
+      EMAIL_ADMIN_ADDRESS  = aws_ssm_parameter.email_admin_address.value,
+      SUPPORT_URL          = aws_ssm_parameter.auth0_support_url.value,
+      SIERRA_API_ROOT      = aws_ssm_parameter.sierra_api_hostname.value,
+      SIERRA_CLIENT_KEY    = local.sierra_api_credentials.client_key,
+      SIERRA_CLIENT_SECRET = local.sierra_api_credentials.client_secret
     }
   }
 

--- a/packages/apps/api/src/app.ts
+++ b/packages/apps/api/src/app.ts
@@ -14,10 +14,12 @@ import {
 } from './handlers/user';
 import { errorHandler } from './handlers/errorHandler';
 import { EmailClient } from './utils/EmailClient';
+import { SierraClient } from '@weco/sierra-client';
 
 export type Clients = {
   auth0: Auth0Client;
   email: EmailClient;
+  sierra: SierraClient;
 };
 
 export function createApplication(clients: Clients): Application {
@@ -56,7 +58,7 @@ function registerUsersUserIdRegistrationResource(
   app.put(
     '/users/:user_id/registration',
     corsOptions,
-    asyncHandler(updateUserAfterRegistration(clients.auth0))
+    asyncHandler(updateUserAfterRegistration(clients.auth0, clients.sierra))
   );
 }
 

--- a/packages/apps/api/src/server-lambda.ts
+++ b/packages/apps/api/src/server-lambda.ts
@@ -29,9 +29,9 @@ const emailClient: EmailClient = new HttpEmailClient(
 );
 
 const sierraClient = new HttpSierraClient(
-  process.env.API_ROOT,
-  process.env.CLIENT_KEY,
-  process.env.CLIENT_SECRET
+  process.env.SIERRA_API_ROOT!,
+  process.env.SIERRA_CLIENT_KEY!,
+  process.env.SIERRA_CLIENT_SECRET!
 );
 
 const app = createApplication({

--- a/packages/apps/api/src/server-lambda.ts
+++ b/packages/apps/api/src/server-lambda.ts
@@ -2,6 +2,7 @@ import { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import * as awsServerlessExpress from 'aws-serverless-express';
 import { Server } from 'http';
 import { HttpAuth0Client, Auth0Client } from '@weco/auth0-client';
+import { HttpSierraClient } from '@weco/sierra-client';
 import { createApplication } from './app';
 import HttpEmailClient, { EmailClient } from './utils/EmailClient';
 
@@ -27,9 +28,16 @@ const emailClient: EmailClient = new HttpEmailClient(
   process.env.SUPPORT_URL!
 );
 
+const sierraClient = new HttpSierraClient(
+  process.env.API_ROOT,
+  process.env.CLIENT_KEY,
+  process.env.CLIENT_SECRET
+);
+
 const app = createApplication({
   auth0: auth0Client,
   email: emailClient,
+  sierra: sierraClient,
 });
 
 const server: Server = awsServerlessExpress.createServer(app, undefined, []);

--- a/packages/apps/api/test/routes/fixtures/mockedApi.ts
+++ b/packages/apps/api/test/routes/fixtures/mockedApi.ts
@@ -1,5 +1,6 @@
 import supertest = require('supertest');
 import { MockAuth0Client } from '@weco/auth0-client';
+import { MockSierraClient } from '@weco/sierra-client';
 import MockEmailClient from './MockEmailClient';
 import { createApplication } from '../../../src/app';
 import { Request } from 'supertest';
@@ -37,6 +38,7 @@ export const mockedApi = (existingUsers: ExistingUser[] = []) => {
   const mockClients = {
     auth0: new MockAuth0Client(),
     email: new MockEmailClient(),
+    sierra: new MockSierraClient(),
   };
 
   for (const user of existingUsers) {

--- a/packages/apps/api/tsconfig.json
+++ b/packages/apps/api/tsconfig.json
@@ -11,6 +11,9 @@
     },
     {
       "path": "../../shared/identity-common"
+    },
+    {
+      "path": "../../shared/sierra-client"
     }
   ]
 }


### PR DESCRIPTION
We have a `createPatron` method available in sierra-client, let's make use of that in `updateUserAfterRegistration`. This means that the full registration form will collect firstName, lastName and update in auth0 and now also create a patron in sierra. 

This is towards overall work for https://github.com/wellcomecollection/wellcomecollection.org/issues/7896 and specifically for https://github.com/wellcomecollection/wellcomecollection.org/issues/8013