### PR TITLE
Allow universal-login template to handle signup as well as login

### DIFF
--- a/universal_login/deploy.ts
+++ b/universal_login/deploy.ts
@@ -10,7 +10,12 @@ import {
 import { applyTemplates } from './scripts/templates';
 
 type Template = 'universal-login';
-const prompts = ['login', 'reset-password', 'email-verification'] as const;
+const prompts = [
+  'login',
+  'reset-password',
+  'email-verification',
+  'signup',
+] as const;
 const emails = [
   'verify_email',
   'welcome_email',

--- a/universal_login/prompt/login.json
+++ b/universal_login/prompt/login.json
@@ -3,6 +3,8 @@
     "pageTitle": "Sign in to your library account",
     "description": " ",
     "buttonText": "Sign in",
+    "footerText": "Not a library member?",
+    "signupActionLinkText": "Apply for a membership",
     "custom-script-error-code": "There is an issue with this library account. To resolve this, please contact Library Enquiries (library@wellcomecollection.org)."
   }
 }

--- a/universal_login/prompt/signup.json
+++ b/universal_login/prompt/signup.json
@@ -1,0 +1,9 @@
+{
+  "signup": {
+    "pageTitle": "Apply for a library membership",
+    "description": " ",
+    "buttonText": "Continue",
+    "loginActionText": "Already have an account?",
+    "loginActionLinkText": "Sign in"
+  }
+}

--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -264,19 +264,21 @@
           library account to sign in. You'll no longer be able to use your
           library card number or username.
         </p>
-        {% endif %} {%- auth0:widget -%} {% if prompt.name == "login" or
-        prompt.name == "signup" %}
+        {% endif %} {% if prompt.name == "signup" %}
         <p>
-          {% if prompt.name == "login" %}
+          For free access to our requesting service, subscription databases and
+          other online resources, please apply for a library membership.
+        </p>
+        <p>
+          <strong>Note:</strong> You don’t need a membership to visit the
+          library for the day or to view our digital collections.
+        </p>
+        {% endif %} {%- auth0:widget -%} {% if prompt.name == "login" %}
+        <p>
           <strong>Having trouble accessing your account?</strong>
           <a href="mailto:library@wellcomecollection.org"
             >Contact the library team.</a
           ><br />
-          {% endif %}
-          <strong>Not a library member?</strong>
-          <a href="https://wellcomecollection.org/pages/X_2eexEAACQAZLBi"
-            >Read more about joining the library.</a
-          >
         </p>
         {% endif %} {% if prompt.screen.name == "reset-password-success" %}
         <p>


### PR DESCRIPTION
[Design on Zeplin](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/6295e3df104e15109c8d365b)

The current login form has the line, 'Not a library member? Read more about joining the library'. We're replacing that with, 'Not a library member? Apply for a membership'. This link is dynamically provided by Auth0 and will have to live within the widget, so this copy will move up (to appear directly below the CTA button).

As this is handled by Auth0, I'm not sure if we can style it exactly the same as it appears currently (i.e. with the first sentence in bold).

On the signup screen, an equivalent piece of copy linking back to the login screen will appear, but again because of the Auth0 limitation, I'm not sure we can bold the first sentence – 'Already have an account? Sign in'.

__TODO:__ figure out how to toggle this because we don't want to go live with it immediately on prod, but can't see how our toggles are available in this context. We _can_ deploy to stage and _look_ at it there, but don't think that'll be sufficient for testing the journey end-to-end.

__Edit:__ we currently style elements inside the Auth0 widget by targeting their classes directly. We'll know what these are for the signup button/text once we've deployed to stage, at which point, I'll put in another pr to style them appropriately, and show/hide based on the presence of the existence of `toggle_enableRequesting=true` in `document.cookie`. We could _possibly_ add the bold text styling with JS as well. I'm not saying we should.
