### PR TITLE
make sure to include sierra-client in package.json

### DIFF
--- a/packages/apps/api/package.json
+++ b/packages/apps/api/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@weco/auth0-client": "*",
     "@weco/identity-common": "*",
+    "@weco/sierra-client": "*",
     "aws-serverless-express": "^3.3.8",
     "express": "^4.17.1",
     "express-async-handler": "^1.1.4",

--- a/packages/shared/sierra-client/package.json
+++ b/packages/shared/sierra-client/package.json
@@ -16,7 +16,6 @@
     "axios": "^0.21.1"
   },
   "devDependencies": {
-    "@types/node": "^17.0.0",
     "jest": "^27.4.3",
     "jest-extended": "^2.0.0",
     "msw": "^0.36.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,7 +2810,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^17.0.0", "@types/node@^17.0.16":
+"@types/node@*", "@types/node@>= 8", "@types/node@^17.0.16":
   version "17.0.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.16.tgz#e3733f46797b9df9e853ca9f719c8a6f7b84cd26"
   integrity sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA==


### PR DESCRIPTION
`@weco/sierra-client` was already available in `tsconfig.json` but I forgot to include it in `package.json`. This should fix the 502 error on smoke tests for the identity api as the module should now be available. 