### PR TITLE
Make sure DOM has element we're targeting loaded

### DIFF
--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -238,16 +238,6 @@
       }
     </style>
     <title>{{ prompt.screen.texts.pageTitle }}</title>
-    <script type="text/javascript">
-      var alternateAction = document.querySelector('._alternate-action');
-      var isSelfRegistrationToggleOn = document.cookie.includes(
-        'toggle_selfRegistration=true'
-      );
-
-      if (isSelfRegistrationToggleOn) {
-        alternateAction.style.display = 'block';
-      }
-    </script>
   </head>
 
   <body class="_hide-prompt-logo">
@@ -308,5 +298,15 @@
         {% endif %}
       </div>
     </div>
+    <script type="text/javascript">
+      var alternateAction = document.querySelector('._alternate-action');
+      var isSelfRegistrationToggleOn = document.cookie.includes(
+        'toggle_selfRegistration=true'
+      );
+
+      if (isSelfRegistrationToggleOn) {
+        alternateAction.style.display = 'block';
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
I had the script in the `<head>` before, so it ran before the elements it was looking for existed in the DOM. Moving before the closing `</body>` tag to fix (and including a belt-and-braces check for the existence of the element before trying to change its style).