### PR TITLE
Use query string to determine showSignup

### DIFF
--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -300,11 +300,11 @@
     </div>
     <script type="text/javascript">
       var alternateAction = document.querySelector('._alternate-action');
-      var isSelfRegistrationToggleOn = document.cookie.includes(
-        'toggle_selfRegistration=true'
-      );
+      var urlParams = new URLSearchParams(window.location.search);
+      var params = (Object.fromEntries && Object.fromEntries(urlParams)) || {};
+      var showRegistration = params.showRegistration === 'true';
 
-      if (isSelfRegistrationToggleOn) {
+      if (showRegistration && alternateAction) {
         alternateAction.style.display = 'block';
       }
     </script>


### PR DESCRIPTION
The toggle cookies are set on `wellcomecollection.org` so won't be available for the login screens at `account.wellcomecollection.org`.

Reading a query param (`showRegistration=true`) out of the URL instead to accomplish the same thing.

