### PR TITLE
Check the host contains 'stage' to determine showing signup link

### DIFF
--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -300,11 +300,9 @@
     </div>
     <script type="text/javascript">
       var alternateAction = document.querySelector('._alternate-action');
-      var urlParams = new URLSearchParams(window.location.search);
-      var params = (Object.fromEntries && Object.fromEntries(urlParams)) || {};
-      var showRegistration = params.showRegistration === 'true';
+      var isStage = window.location.host.includes('stage');
 
-      if (showRegistration && alternateAction) {
+      if (isStage && alternateAction) {
         alternateAction.style.display = 'block';
       }
     </script>


### PR DESCRIPTION
It seems like we should be able to [encode/decode arbitrary data in the `state` parameter](https://github.com/auth0/nextjs-auth0/blob/a7a588d651eee571e7aa8ee881fbabbcd61153d6/src/auth0-session/hooks/get-login-state.ts#L35) on the Auth0 hosted form screens, but I haven't been able to make this work. For now I've resorted to checking the host is stage.