### PR TITLE
updating createPatron with note

### DIFF
--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -83,7 +83,7 @@ export default class HttpSierraClient implements SierraClient {
         const messages = {
           // When new Membership self registration testing phase 1 is over we can query by registrationTestingNote and remove any test accounts from Sierra
           registrationTestingNote:
-            'this user was created during initial testing for registration. Please contact the Digital Engagement team if you encounter any issues or have any questions digitalengagement@wellcome.org',
+            'this user was created during initial testing for registration. Please contact the Digital Engagement team if you encounter any issues or have any questions digital@wellcomecollection.org',
           // We will want to keep a permanent record of any users who have registered through the new Membership self registration through auth0
           registrationDetails:
             'this user was created using membership sign-up via auth0 from weco.org',


### PR DESCRIPTION
 We want any patrons created from Membership Phase 1 via auth0 registration to have a note that tells us this. We will use this note as a way to delete patrons creating during testing, but we will also keep a note in place to indicate the registration is from auth0. 