### PR TITLE
update the get user script

### DIFF
--- a/packages/apps/auth0-database-scripts/src/get_user.ts
+++ b/packages/apps/auth0-database-scripts/src/get_user.ts
@@ -23,7 +23,9 @@ async function getUser(email: string): Promise<Auth0User | undefined> {
     const patronRecord = patronRecordResponse.result;
     return patronRecordToUser(patronRecord);
   } else if (patronRecordResponse.status === ResponseStatus.NotFound) {
-    return undefined;
+    // If a user is not found in sierra, we should be able to create the user in
+    // the next script that runs, 'create'
+    return;
   } else {
     throw new Error(patronRecordResponse.message);
   }


### PR DESCRIPTION
 We are testing patron creation through auth0 'create' script. We notice that we are getting a particular error which suggests the json is invalid. 

```Malformed or invalid Patron creation request (cause: [{\"code\":115,\"specificCode\":0,\"httpStatus\":400,\"name\":\"Invalid JSON\",\"description\":\"Invalid JSON : field(s) unknown : params.\"}])```

I have a feeling this will return undefined values for certain fields we are trying to populate in the POST create patron. If we just return, I'm hoping we get the values we need. 

FYI The flow of auth0 scripts
1. Get user script
2. Create user script
3. Login script