### PR TITLE
adding pin to createPatron

### DIFF
--- a/packages/apps/auth0-database-scripts/src/create.ts
+++ b/packages/apps/auth0-database-scripts/src/create.ts
@@ -2,6 +2,7 @@ import { callbackify } from 'util';
 import { Auth0User } from '@weco/auth0-client';
 import { ResponseStatus } from '@weco/identity-common';
 import { HttpSierraClient, SierraClient } from '@weco/sierra-client';
+import { Auth0UserWithPassword } from '@weco/auth0-client/src/auth0';
 
 declare const configuration: {
   API_ROOT: string;
@@ -12,7 +13,7 @@ declare const configuration: {
 const userAlreadyExistsMessage =
   'A user with this email address already exists.';
 
-async function create(user: Auth0User) {
+async function create(user: Auth0UserWithPassword) {
   // We need to create the patron in sierra, we will update the patron info with firstName, lastName etc
   // when we get this information from the full registration form
 
@@ -31,7 +32,6 @@ async function create(user: Auth0User) {
     tempLastName,
     tempFirstName,
     user.email,
-    // @ts-ignore
     user.password
   );
   if (createPatronResponse.status === ResponseStatus.UserAlreadyExists) {

--- a/packages/apps/auth0-database-scripts/src/create.ts
+++ b/packages/apps/auth0-database-scripts/src/create.ts
@@ -24,12 +24,15 @@ async function create(user: Auth0User) {
   const tempLastName = 'Auth0_Registration_tempLastName';
 
   const sierraClient = new HttpSierraClient(apiRoot, clientKey, clientSecret);
+
   const createPatronResponse = await sierraClient.createPatron(
     // We temporarily set a first and lastName that is easier to find that way we
     // can delete users that don't finish the full registration process
     tempLastName,
     tempFirstName,
-    user.email
+    user.email,
+    // @ts-ignore
+    user.password
   );
   if (createPatronResponse.status === ResponseStatus.UserAlreadyExists) {
     throw new ValidationError(user.email, userAlreadyExistsMessage);

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -25,6 +25,11 @@ export type AppMetadata = {
 // Makes the keys K of T required
 type WithRequiredFields<T, K extends keyof T> = T & Required<Pick<T, K>>;
 
+// In the create script we want to be able to get the password from the user object
+export type Auth0UserWithPassword = Auth0User & {
+  password: string;
+};
+
 export type Auth0User = WithRequiredFields<
   User<AppMetadata, UserMetadata>,
   'user_id' | 'email' // These fields are always present

--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -74,7 +74,8 @@ export default class HttpSierraClient implements SierraClient {
   async createPatron(
     lastName: string,
     firstName: string,
-    email: string
+    email: string,
+    password: string
   ): Promise<APIResponse<PatronCreateResponse>> {
     return this.getInstance().then(async (instance) => {
       try {
@@ -99,6 +100,7 @@ export default class HttpSierraClient implements SierraClient {
           '/patrons/',
           {
             patronType: 29,
+            pin: password,
             varFields: [
               {
                 fieldTag: 'n',

--- a/packages/shared/sierra-client/src/SierraClient.ts
+++ b/packages/shared/sierra-client/src/SierraClient.ts
@@ -11,7 +11,8 @@ export default interface SierraClient {
   createPatron(
     lastName: string,
     email: string,
-    firstName: string
+    firstName: string,
+    password: string
   ): Promise<APIResponse<PatronCreateResponse>>;
 
   getDeletedRecordNumbers(options?: {

--- a/packages/shared/sierra-client/tests/http-sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/http-sierra-client.test.ts
@@ -55,6 +55,7 @@ describe('HTTP sierra client', () => {
       lastName: 'Ravioli',
       firstName: 'Ravi',
       email: 'raviravioli@pastatimestest.com',
+      password: '12345abcdefg',
     };
     mockSierraServer.use(
       rest.post(routeUrls.patron, (req, res, ctx) => res(ctx.json(newPatron)))
@@ -64,7 +65,8 @@ describe('HTTP sierra client', () => {
       const response = await client.createPatron(
         'Ravioli',
         'Ravi',
-        'raviravioli@ppastatimestest.com'
+        'raviravioli@ppastatimestest.com',
+        '12345abcdefg'
       );
 
       expect(response.status).toBe(ResponseStatus.Success);

--- a/packages/shared/sierra-client/tests/http-sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/http-sierra-client.test.ts
@@ -65,7 +65,7 @@ describe('HTTP sierra client', () => {
       const response = await client.createPatron(
         'Ravioli',
         'Ravi',
-        'raviravioli@ppastatimestest.com',
+        'raviravioli@pastatimestest.com',
         '12345abcdefg'
       );
 


### PR DESCRIPTION
A user needs their password to be set on sierra, we can now do this at point of patron creation in create script. 

**Updated Note**: Based on a nifty suggestion by David I've added a new Auth0 type that contains password. 

**Note:** ~I've temporarily put a ts-ignore in for `user.password` as I can't see how to type this within the current existing type for Auth0User shown below, if anyone has any guidance on how best to type in this context it would be greatly appreciated. [Auth0 docs](https://auth0.com/docs/authenticate/database-connections/custom-db/templates/create#user-object-example) suggest that password is available from Auth0User.~

```
 export type Auth0User = WithRequiredFields<
  User<AppMetadata, UserMetadata>,
  'user_id' | 'email' // These fields are always present
>;
```

related to work on https://github.com/wellcomecollection/wellcomecollection.org/issues/8071, https://github.com/wellcomecollection/wellcomecollection.org/issues/8072 and https://github.com/wellcomecollection/wellcomecollection.org/issues/7896 