### PR TITLE
Temporary console logs to debug login script

### DIFF
--- a/packages/apps/auth0-database-scripts/src/login.ts
+++ b/packages/apps/auth0-database-scripts/src/login.ts
@@ -22,9 +22,15 @@ async function login(email: string, password: string): Promise<Auth0User> {
 
   const patronRecordResponse = await sierraClient.getPatronRecordByEmail(email);
   if (patronRecordResponse.status === ResponseStatus.NotFound) {
+    console.log(
+      'LOG >> login script >> line 24 >> We have not found the patron in Sierra '
+    );
     throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
   }
   if (patronRecordResponse.status !== ResponseStatus.Success) {
+    console.log(
+      'LOG >> login script >> line 28 >> There was some other error in finding the patron in Sierra '
+    );
     throw new Error(patronRecordResponse.message);
   }
 
@@ -34,6 +40,9 @@ async function login(email: string, password: string): Promise<Auth0User> {
     password
   );
   if (validationResponse.status !== ResponseStatus.Success) {
+    console.log(
+      'LOG >> login script >> line 38 >> We had an issue in running validation of the patron in Sierra'
+    );
     throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
   }
 
@@ -42,11 +51,17 @@ async function login(email: string, password: string): Promise<Auth0User> {
   // requires that they set a password via email, we assume that their current
   // email address is verified, and mark it as such.
   if (!patronRecord.verifiedEmail) {
+    console.log(
+      'LOG >> login script >> line 47 >> We we able to find out the patron was not verified in Sierra '
+    );
     const updatedRecordResponse = await sierraClient.markPatronEmailVerified(
       patronRecord.recordNumber,
       { type: 'Implicit' }
     );
     if (updatedRecordResponse.status !== ResponseStatus.Success) {
+      console.log(
+        'LOG >> login script >> line 53 >> We encountered an error in marking the patron as verified in Sierra '
+      );
       throw new Error(updatedRecordResponse.message);
     }
     return patronRecordToUser(updatedRecordResponse.result);

--- a/packages/apps/auth0-database-scripts/src/login.ts
+++ b/packages/apps/auth0-database-scripts/src/login.ts
@@ -29,7 +29,7 @@ async function login(email: string, password: string): Promise<Auth0User> {
   }
   if (patronRecordResponse.status !== ResponseStatus.Success) {
     console.log(
-      'LOG >> login script >> line 28 >> There was some other error in finding the patron in Sierra '
+      'LOG >> login script >> line 30 >> There was some other error in finding the patron in Sierra '
     );
     throw new Error(patronRecordResponse.message);
   }
@@ -41,7 +41,7 @@ async function login(email: string, password: string): Promise<Auth0User> {
   );
   if (validationResponse.status !== ResponseStatus.Success) {
     console.log(
-      'LOG >> login script >> line 38 >> We had an issue in running validation of the patron in Sierra'
+      'LOG >> login script >> line 42 >> We had an issue in running validation of the patron in Sierra'
     );
     throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
   }
@@ -52,7 +52,7 @@ async function login(email: string, password: string): Promise<Auth0User> {
   // email address is verified, and mark it as such.
   if (!patronRecord.verifiedEmail) {
     console.log(
-      'LOG >> login script >> line 47 >> We we able to find out the patron was not verified in Sierra '
+      'LOG >> login script >> line 53 >> We we able to find out the patron was not verified in Sierra '
     );
     const updatedRecordResponse = await sierraClient.markPatronEmailVerified(
       patronRecord.recordNumber,
@@ -60,7 +60,7 @@ async function login(email: string, password: string): Promise<Auth0User> {
     );
     if (updatedRecordResponse.status !== ResponseStatus.Success) {
       console.log(
-        'LOG >> login script >> line 53 >> We encountered an error in marking the patron as verified in Sierra '
+        'LOG >> login script >> line 61 >> We encountered an error in marking the patron as verified in Sierra '
       );
       throw new Error(updatedRecordResponse.message);
     }


### PR DESCRIPTION
We need to check at what point the login script is throwing an error so we can debug. Console logs contain strings and don't log out any information from the script beyond hard-coded line numbers.

related to work on https://github.com/wellcomecollection/wellcomecollection.org/issues/8071 and https://github.com/wellcomecollection/wellcomecollection.org/issues/7896