### PR TITLE
implement a new updateBarcode method

### DIFF
--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -463,7 +463,7 @@ export default class HttpSierraClient implements SierraClient {
           switch (error.response.status) {
             case 404:
               return errorResponse(
-                'Patron record with email address [' +
+                'Patron record with recordNumber [' +
                   recordNumber +
                   '] not found',
                 ResponseStatus.NotFound,

--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -443,6 +443,38 @@ export default class HttpSierraClient implements SierraClient {
     });
   }
 
+  async updateBarcode(
+    recordNumber: number,
+    barcode: string
+  ): Promise<APIResponse<PatronRecord>> {
+    return this.getInstance().then((instance) => {
+      return instance
+        .put(
+          '/patrons/' + recordNumber,
+          {
+            barcode: [barcode],
+          },
+          {
+            validateStatus: (status) => status === 204,
+          }
+        )
+        .then(() => this.getPatronRecordByRecordNumber(recordNumber))
+        .catch((error) => {
+          switch (error.response.status) {
+            case 404:
+              return errorResponse(
+                'Patron record with email address [' +
+                  recordNumber +
+                  '] not found',
+                ResponseStatus.NotFound,
+                error
+              );
+          }
+          return unhandledError(error);
+        });
+    });
+  }
+
   private getInstance = authenticatedInstanceFactory(
     async () => {
       const response = await axios.post(

--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -452,7 +452,7 @@ export default class HttpSierraClient implements SierraClient {
         .put(
           '/patrons/' + recordNumber,
           {
-            barcode: [barcode],
+            barcodes: [barcode],
           },
           {
             validateStatus: (status) => status === 204,


### PR DESCRIPTION
We need to create the patron in order to know the recordNumber (patron id), we can then set the patron's barcode as the patron id using updateBarcode. 

**Based on:**
- Testing sign up currently fails within login script
- I think the point of failure happens around `validateCredentials` as this expects a barcode and password, we have not set a barcode at patron creation
- We found current format of self registered patron's barcode is initially based on recordNumber

**Helpful to know:**
The format of barcode with self registered patron object on sierra 
```
{
	"id": 12345,
	"barcodes": [
		"12345"
	]
}
```

related to work on https://github.com/wellcomecollection/wellcomecollection.org/issues/8071 and https://github.com/wellcomecollection/wellcomecollection.org/issues/7896