### PR TITLE
update patron first and lastname

### DIFF
--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -77,17 +77,8 @@ export function updateUserAfterRegistration(
       throw clientResponseToHttpError(auth0Update);
     }
 
-    // Get the patron recordNumber
-    const getPatronRecordResponse = await sierraClient.getPatronRecordByEmail(
-      auth0Profile.email
-    );
-    if (getPatronRecordResponse.status !== ResponseStatus.Success) {
-      throw clientResponseToHttpError(getPatronRecordResponse);
-    }
-    const { recordNumber } = getPatronRecordResponse.result;
-
     // Update the patron record with the incoming full registration first and lastname
-    const createPatronResponse = await sierraClient.updatePatron(recordNumber, {
+    const updatePatronResponse = await sierraClient.updatePatron(userId, {
       varFields: {
         fieldTag: varFieldTags.name,
         subfields: [
@@ -102,8 +93,8 @@ export function updateUserAfterRegistration(
         ],
       },
     });
-    if (createPatronResponse.status !== ResponseStatus.Success) {
-      throw clientResponseToHttpError(createPatronResponse);
+    if (updatePatronResponse.status !== ResponseStatus.Success) {
+      throw clientResponseToHttpError(updatePatronResponse);
     }
 
     response.status(200).json(toUser(auth0Update.result));

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -59,17 +59,8 @@ export function updateUserAfterRegistration(
     const firstName: string = request.body.firstName;
     const lastName: string = request.body.lastName;
 
-    const auth0UserIdGet: APIResponse<Auth0User> = await auth0Client.getUserByUserId(
-      userId
-    );
-    if (auth0UserIdGet.status !== ResponseStatus.Success) {
-      throw clientResponseToHttpError(auth0UserIdGet);
-    }
-    const auth0Profile: Auth0User = auth0UserIdGet.result;
-
     const auth0Update: APIResponse<Auth0User> = await auth0Client.updateUser({
       userId,
-      email: auth0Profile.email,
       firstName,
       lastName,
     });

--- a/packages/shared/auth0-client/src/Auth0Client.ts
+++ b/packages/shared/auth0-client/src/Auth0Client.ts
@@ -3,7 +3,7 @@ import { AppMetadata, Auth0User } from './auth0';
 
 export type Auth0UserInput = {
   userId: number;
-  email: string;
+  email?: string;
   firstName?: string;
   lastName?: string;
 };

--- a/packages/shared/auth0-client/src/HttpAuth0Client.ts
+++ b/packages/shared/auth0-client/src/HttpAuth0Client.ts
@@ -124,20 +124,14 @@ export default class HttpAuth0Client implements Auth0Client {
               name: `${firstName} ${lastName}`,
             }
           : {};
+      // We only need to update the email value if it is provided, this allows us to update first and lastname without needing an email too
+      const updateData = email
+        ? { email: email, verify_email: true, connection: SierraConnection }
+        : { connection: SierraConnection, ...names };
       return instance
-        .patch(
-          '/users/' + SierraUserIdPrefix + userId,
-          {
-            // Automatically append the mandatory Auth0 prefix to the given user ID.
-            email: email,
-            verify_email: true,
-            connection: SierraConnection,
-            ...names,
-          },
-          {
-            validateStatus: (status) => status === 200,
-          }
-        )
+        .patch('/users/' + SierraUserIdPrefix + userId, updateData, {
+          validateStatus: (status) => status === 200,
+        })
         .then((response) => successResponse(response.data))
         .catch((error) => {
           if (error.response) {

--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -211,7 +211,7 @@ export type VarField = {
 export type UpdateOptions = {
   pin?: string;
   barcodes?: [barcode: string];
-  fieldTag?: VarFieldTag;
+  varFields?: VarField;
 };
 
 type SubField = {


### PR DESCRIPTION
Once we get the first and lastname through to Identity api registration endpoint we need to be able to update their record on Sierra with the incoming first and lastname.
