### PR TITLE
make sure varFieldTags is available

### DIFF
--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -5,8 +5,7 @@ import { toMessage } from '../models/common';
 import { clientResponseToHttpError, HttpError } from '../models/HttpError';
 import { toUser } from '../models/user';
 import { EmailClient } from '../utils/EmailClient';
-import { SierraClient } from '@weco/sierra-client';
-import { varFieldTags } from '@weco/sierra-client/src/patron';
+import { SierraClient, varFieldTags } from '@weco/sierra-client';
 
 export function validatePassword(auth0Client: Auth0Client) {
   const checkPassword = passwordCheckerForUser(auth0Client);

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -2,5 +2,5 @@ import SierraClient from './SierraClient';
 import HttpSierraClient from './HttpSierraClient';
 import MockSierraClient from './MockSierraClient';
 
-export { PatronRecord } from './patron';
+export { PatronRecord, varFieldTags } from './patron';
 export { HttpSierraClient, MockSierraClient, SierraClient };


### PR DESCRIPTION
I had required a function that I didn't make available properly resulting in an error 

```
 "Error: Cannot find module '@weco/sierra-client/src/patron'\nRequire stack:\n- /var/task/handlers/user.js\n- /var/task/app.js\n- /var/task/server-lambda.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js",
```