### PR TITLE
Set the principal ID to `@machine` for machine users

### DIFF
--- a/packages/apps/api-authorizer/src/handler.test.ts
+++ b/packages/apps/api-authorizer/src/handler.test.ts
@@ -13,7 +13,7 @@ describe('choosePrincipalId', () => {
       },
     };
 
-    expect(choosePrincipalId(token)).toBe('p1234567');
+    expect(choosePrincipalId(token)).toBe('1234567');
   });
 
   it('sets a machine ID if we’re in the client-credentials flow', () => {

--- a/packages/apps/api-authorizer/src/handler.test.ts
+++ b/packages/apps/api-authorizer/src/handler.test.ts
@@ -1,0 +1,61 @@
+import { choosePrincipalId } from './handler';
+
+describe('choosePrincipalId', () => {
+  it('uses a Sierra patron ID if provided', () => {
+    const token = {
+      header: {
+        alg: 'RS256',
+        typ: 'JWT',
+      },
+      signature: '',
+      payload: {
+        sub: 'auth0|p1234567',
+      },
+    };
+
+    expect(choosePrincipalId(token)).toBe('p1234567');
+  });
+
+  it('sets a machine ID if we’re in the client-credentials flow', () => {
+    const token = {
+      header: {
+        alg: 'RS256',
+        typ: 'JWT',
+      },
+      signature: '',
+      payload: {
+        sub: '1234567@clients',
+      },
+    };
+
+    expect(choosePrincipalId(token)).toBe('@machine');
+  });
+
+  it('returns the subject unmodified if it can’t identify a principal', () => {
+    const token = {
+      header: {
+        alg: 'RS256',
+        typ: 'JWT',
+      },
+      signature: '',
+      payload: {
+        sub: 'mysterySubject',
+      },
+    };
+    expect(choosePrincipalId(token)).toBe('mysterySubject');
+  });
+
+  it('returns an empty string if the subject is missing', () => {
+    const token = {
+      header: {
+        alg: 'RS256',
+        typ: 'JWT',
+      },
+      signature: '',
+      payload: {
+        sub: undefined,
+      },
+    };
+    expect(choosePrincipalId(token)).toBe('');
+  });
+});

--- a/packages/shared/auth0-client/src/auth0.ts
+++ b/packages/shared/auth0-client/src/auth0.ts
@@ -7,7 +7,7 @@ export const auth0IdToPublic = (subjectClaim?: string): string | undefined => {
   if (subjectClaim?.startsWith(SierraUserIdPrefix)) {
     return subjectClaim.slice(SierraUserIdPrefix.length);
   } else {
-    return subjectClaim;
+    return undefined;
   }
 };
 


### PR DESCRIPTION
This is just the authorizer; there's another piece of work in the identity API to get it to recognise this `@machine` value, but I'll do that separately.