### PR TITLE
Check a user is mid-registration when updating their name

### DIFF
--- a/packages/apps/api/src/app.ts
+++ b/packages/apps/api/src/app.ts
@@ -58,7 +58,7 @@ function registerUsersUserIdRegistrationResource(
   app.put(
     '/users/:user_id/registration',
     corsOptions,
-    asyncHandler(updateUserAfterRegistration(clients.auth0, clients.sierra))
+    asyncHandler(updateUserAfterRegistration(clients.sierra))
   );
 }
 

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -63,13 +63,17 @@ export function updateUserAfterRegistration(
     // We retrieve the existing patron record and check it has the placeholder
     // values we store for a user when they're created; if not, we reject the
     // request because something has gone wrong.
-    const patronResponse = await sierraClient.getPatronRecordByRecordNumber(userId);
+    const getPatronResponse = await sierraClient.getPatronRecordByRecordNumber(userId);
 
-    if (patronResponse.status === ResponseStatus.NotFound) {
+    if (getPatronResponse.status === ResponseStatus.NotFound) {
       throw new HttpError({
         status: 404,
         message: 'User does not exist'
       })
+    }
+
+    if (getPatronResponse.status !== ResponseStatus.Success) {
+      throw clientResponseToHttpError(getPatronResponse);
     }
 
     // Update the patron record with the incoming full registration first and lastname

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -5,7 +5,7 @@ import { toMessage } from '../models/common';
 import { clientResponseToHttpError, HttpError } from '../models/HttpError';
 import { toUser } from '../models/user';
 import { EmailClient } from '../utils/EmailClient';
-import { SierraClient, varFieldTags } from '@weco/sierra-client';
+import { SierraClient, PatronRecord, varFieldTags } from '@weco/sierra-client';
 
 export function validatePassword(auth0Client: Auth0Client) {
   const checkPassword = passwordCheckerForUser(auth0Client);
@@ -50,7 +50,6 @@ export function getUser(auth0Client: Auth0Client) {
 }
 
 export function updateUserAfterRegistration(
-  auth0Client: Auth0Client,
   sierraClient: SierraClient
 ) {
   return async function (request: Request, response: Response): Promise<void> {
@@ -58,36 +57,68 @@ export function updateUserAfterRegistration(
     const firstName: string = request.body.firstName;
     const lastName: string = request.body.lastName;
 
-    const auth0Update: APIResponse<Auth0User> = await auth0Client.updateUser({
-      userId,
-      firstName,
-      lastName,
-    });
-    if (auth0Update.status !== ResponseStatus.Success) {
-      throw clientResponseToHttpError(auth0Update);
+    // This is a very powerful endpoint, and we don't want it to be misused
+    // to overwrite the first/last name of existing patrons.
+    //
+    // We retrieve the existing patron record and check it has the placeholder
+    // values we store for a user when they're created; if not, we reject the
+    // request because something has gone wrong.
+    const patronResponse = await sierraClient.getPatronRecordByRecordNumber(userId);
+
+    if (patronResponse.status === ResponseStatus.NotFound) {
+      throw new HttpError({
+        status: 404,
+        message: 'User does not exist'
+      })
     }
 
     // Update the patron record with the incoming full registration first and lastname
+    //
+    // Note: we only update the patron record in Sierra, not Auth0, because you
+    // can't update the name of Auth0 with our setup.  If you try, you get an error:
+    //
+    //    The following user attributes cannot be updated: family_name, given_name, name.
+    //    The connection (Sierra-Connection) must either be a database connection (using
+    //    the Auth0 store), a passwordless connection (email or sms) or has disabled
+    //    'Sync user profile attributes at each login'.
+    //
+    //    For more information, see
+    //    https://auth0.com/docs/dashboard/guides/connections/configure-connection-sync
+    //
+    // Because patron data is refreshed every time a user authenticates, we think that
+    // this is okay:
+    //
+    //    1.  User goes to the email/password sign-up form.  This creates a stub user
+    //        in Sierra with a placeholder name.
+    //    2.  User goes to the "fill in your name" form.  At this point they aren't
+    //        logged in.
+    //    3.  User completes that form, gets logged in, triggering an authentication
+    //        and a refresh of patron data.
+    //
+    // We need the full flow working to test this, but this is why we think we can get
+    // away with just an update in Sierra.
     const updatePatronResponse = await sierraClient.updatePatron(userId, {
-      varFields: {
-        fieldTag: varFieldTags.name,
-        subfields: [
-          {
-            tag: 'a',
-            content: lastName,
-          },
-          {
-            tag: 'b',
-            content: firstName,
-          },
-        ],
-      },
+      varFields: [
+        {
+          fieldTag: varFieldTags.name,
+          subfields: [
+            {
+              tag: 'a',
+              content: lastName,
+            },
+            {
+              tag: 'b',
+              content: firstName,
+            },
+          ],
+        }
+      ],
     });
     if (updatePatronResponse.status !== ResponseStatus.Success) {
       throw clientResponseToHttpError(updatePatronResponse);
     }
 
-    response.status(200).json(toUser(auth0Update.result));
+    response.sendStatus(204);
   };
 }
 

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -49,9 +49,7 @@ export function getUser(auth0Client: Auth0Client) {
   };
 }
 
-export function updateUserAfterRegistration(
-  sierraClient: SierraClient
-) {
+export function updateUserAfterRegistration(sierraClient: SierraClient) {
   return async function (request: Request, response: Response): Promise<void> {
     const userId: number = getTargetUserId(request);
     const firstName: string = request.body.firstName;
@@ -63,13 +61,15 @@ export function updateUserAfterRegistration(
     // We retrieve the existing patron record and check it has the placeholder
     // values we store for a user when they're created; if not, we reject the
     // request because something has gone wrong.
-    const getPatronResponse = await sierraClient.getPatronRecordByRecordNumber(userId);
+    const getPatronResponse = await sierraClient.getPatronRecordByRecordNumber(
+      userId
+    );
 
     if (getPatronResponse.status === ResponseStatus.NotFound) {
       throw new HttpError({
         status: 404,
-        message: 'User does not exist'
-      })
+        message: 'User does not exist',
+      });
     }
 
     if (getPatronResponse.status !== ResponseStatus.Success) {
@@ -81,18 +81,23 @@ export function updateUserAfterRegistration(
     //
     // This makes the endpoint idempotent, and guards against annoying errors,
     // e.g. if the identity web app sends the PUT request twice.
-    if (getPatronResponse.result.firstName === firstName && getPatronResponse.result.lastName === lastName) {
+    if (
+      getPatronResponse.result.firstName === firstName &&
+      getPatronResponse.result.lastName === lastName
+    ) {
       response.sendStatus(204);
       return;
     }
 
     // If somebody comes through this flow and the name in Sierra isn't our placeholder,
     // then shenanigans might be occurring. Throw an error; a human needs to look at this.
-    if (getPatronResponse.result.firstName !== 'Auth0_Registration_undefined' ||
-        getPatronResponse.result.lastName !== 'Auth0_Registration_tempLastName') {
+    if (
+      getPatronResponse.result.firstName !== 'Auth0_Registration_undefined' ||
+      getPatronResponse.result.lastName !== 'Auth0_Registration_tempLastName'
+    ) {
       throw new HttpError({
         status: 409,
-        message: `User ${userId} is already registered in Sierra.`
+        message: `User ${userId} is already registered in Sierra.`,
       });
     }
 
@@ -135,7 +140,7 @@ export function updateUserAfterRegistration(
               content: firstName,
             },
           ],
-        }
+        },
       ],
     });
     if (updatePatronResponse.status !== ResponseStatus.Success) {

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -91,7 +91,7 @@ export function updateUserAfterRegistration(
     if (getPatronResponse.result.firstName !== 'Auth0_Registration_undefined' ||
         getPatronResponse.result.lastName !== 'Auth0_Registration_tempLastName') {
       throw new HttpError({
-        status: 400,
+        status: 409,
         message: `User ${userId} is already registered in Sierra.`
       });
     }

--- a/packages/apps/api/test/routes/fixtures/mockedApi.ts
+++ b/packages/apps/api/test/routes/fixtures/mockedApi.ts
@@ -1,6 +1,6 @@
 import supertest = require('supertest');
 import { MockAuth0Client } from '@weco/auth0-client';
-import { MockSierraClient } from '@weco/sierra-client';
+import { MockSierraClient, Role } from '@weco/sierra-client';
 import MockEmailClient from './MockEmailClient';
 import { createApplication } from '../../../src/app';
 import { Request } from 'supertest';
@@ -13,7 +13,7 @@ export type ExistingUser = {
   password?: string;
   markedForDeletion?: boolean;
   emailValidated?: boolean;
-  role?: string;
+  role?: Role;
 };
 
 const apiGatewayHeaders = (data: object = {}) => {
@@ -56,6 +56,18 @@ export const mockedApi = (existingUsers: ExistingUser[] = []) => {
           barcode: Math.floor(Math.random() * 1e8).toString(),
           role: user.role ?? 'Reader',
         },
+      },
+      user.password
+    );
+
+    mockClients.sierra.addPatron(
+      {
+        recordNumber: user.userId,
+        barcode: user.userId.toString(),
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        role: user.role ?? 'Reader',
       },
       user.password
     );

--- a/packages/apps/api/test/routes/users_user_id_registration.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_registration.test.ts
@@ -74,7 +74,7 @@ describe('/users/{userId}/registration', () => {
           .send({ firstName, lastName })
       );
 
-      expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(409);
 
       const sierraUser = await clients.sierra.getPatronRecordByRecordNumber(
         testUser.userId

--- a/packages/apps/api/test/routes/users_user_id_registration.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_registration.test.ts
@@ -62,7 +62,10 @@ describe('/users/{userId}/registration', () => {
     it('409s if a user is already registered', async () => {
       const firstName = 'Silas';
       const lastName = 'Burroughs';
-      const testUser = randomExistingUser({ firstName: 'Henry', lastName: 'Wellcome' });
+      const testUser = randomExistingUser({
+        firstName: 'Henry',
+        lastName: 'Wellcome',
+      });
       const { api, clients } = mockedApi([testUser]);
 
       const response = await withCallerId('@machine')(

--- a/packages/apps/api/test/routes/users_user_id_registration.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_registration.test.ts
@@ -59,7 +59,7 @@ describe('/users/{userId}/registration', () => {
       }
     });
 
-    it('400s if a user is already registered', async () => {
+    it('409s if a user is already registered', async () => {
       const firstName = 'Silas';
       const lastName = 'Burroughs';
       const testUser = randomExistingUser({ firstName: 'Henry', lastName: 'Wellcome' });

--- a/packages/apps/api/test/routes/users_user_id_registration.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_registration.test.ts
@@ -10,26 +10,17 @@ describe('/users/{userId}/registration', () => {
       const testUser = randomExistingUser({ firstName: 'Auth0_Registration_undefined', lastName: 'Auth0_Registration_tempLastName' });
       const { api, clients } = mockedApi([testUser]);
 
-      console.log('@@AWLC 1');
-
       const response = await withCallerId('@machine')(
         api
           .put(`/users/${testUser.userId}/registration`)
           .send({ firstName, lastName })
-          // .set('Accept', 'application/json')
       );
 
-      console.log('@@AWLC 2');
-
       expect(response.statusCode).toBe(204);
-
-      console.log('@@AWLC 3');
 
       const sierraUser = await clients.sierra.getPatronRecordByRecordNumber(
         testUser.userId
       );
-
-      console.log('@@AWLC 4');
 
       if (sierraUser.status === ResponseStatus.Success) {
         expect(sierraUser.result.firstName).toBe(firstName);
@@ -37,21 +28,19 @@ describe('/users/{userId}/registration', () => {
       } else {
         throw new Error(`Unexpected failure from Sierra: ${sierraUser}`);
       }
-
-      console.log('@@AWLC 5');
     });
 
-    // it('404s for users that do not exist', async () => {
-    //   const { api } = mockedApi();
-    //   const id = 6666666;
-    //   const response = await withCallerId('@machine')(
-    //     api
-    //       .put(`/users/${id}/registration`)
-    //       .send({ newPassword: 'firstName', password: 'lastName' })
-    //       .set('Accept', 'application/json')
-    //   );
+    it('404s for users that do not exist', async () => {
+      const { api } = mockedApi();
+      const id = 6666666;
+      const response = await withCallerId('@machine')(
+        api
+          .put(`/users/${id}/registration`)
+          .send({ newPassword: 'firstName', password: 'lastName' })
+          .set('Accept', 'application/json')
+      );
 
-    //   expect(response.statusCode).toBe(404);
-    // });
+      expect(response.statusCode).toBe(404);
+    });
   });
 });

--- a/packages/apps/api/test/routes/users_user_id_registration.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_registration.test.ts
@@ -1,0 +1,57 @@
+import { mockedApi, withCallerId } from './fixtures/mockedApi';
+import { ResponseStatus } from '@weco/identity-common';
+import { randomExistingUser } from './fixtures/generators';
+
+describe('/users/{userId}/registration', () => {
+  describe('PUT /users/{userId}/registration', () => {
+    it('changes the name in Sierra', async () => {
+      const firstName = 'Jane';
+      const lastName = 'Smith';
+      const testUser = randomExistingUser({ firstName: 'Auth0_Registration_undefined', lastName: 'Auth0_Registration_tempLastName' });
+      const { api, clients } = mockedApi([testUser]);
+
+      console.log('@@AWLC 1');
+
+      const response = await withCallerId('@machine')(
+        api
+          .put(`/users/${testUser.userId}/registration`)
+          .send({ firstName, lastName })
+          // .set('Accept', 'application/json')
+      );
+
+      console.log('@@AWLC 2');
+
+      expect(response.statusCode).toBe(204);
+
+      console.log('@@AWLC 3');
+
+      const sierraUser = await clients.sierra.getPatronRecordByRecordNumber(
+        testUser.userId
+      );
+
+      console.log('@@AWLC 4');
+
+      if (sierraUser.status === ResponseStatus.Success) {
+        expect(sierraUser.result.firstName).toBe(firstName);
+        expect(sierraUser.result.lastName).toBe(lastName);
+      } else {
+        throw new Error(`Unexpected failure from Sierra: ${sierraUser}`);
+      }
+
+      console.log('@@AWLC 5');
+    });
+
+    // it('404s for users that do not exist', async () => {
+    //   const { api } = mockedApi();
+    //   const id = 6666666;
+    //   const response = await withCallerId('@machine')(
+    //     api
+    //       .put(`/users/${id}/registration`)
+    //       .send({ newPassword: 'firstName', password: 'lastName' })
+    //       .set('Accept', 'application/json')
+    //   );
+
+    //   expect(response.statusCode).toBe(404);
+    // });
+  });
+});

--- a/packages/apps/api/test/routes/users_user_id_registration.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_registration.test.ts
@@ -1,5 +1,6 @@
 import { mockedApi, withCallerId } from './fixtures/mockedApi';
-import { ResponseStatus } from '@weco/identity-common';
+import { ResponseStatus, SuccessResponse } from '@weco/identity-common';
+import { PatronRecord } from '@weco/sierra-client';
 import { randomExistingUser } from './fixtures/generators';
 
 describe('/users/{userId}/registration', () => {
@@ -51,12 +52,11 @@ describe('/users/{userId}/registration', () => {
         testUser.userId
       );
 
-      if (sierraUser.status === ResponseStatus.Success) {
-        expect(sierraUser.result.firstName).toBe(firstName);
-        expect(sierraUser.result.lastName).toBe(lastName);
-      } else {
-        throw new Error(`Unexpected failure from Sierra: ${sierraUser}`);
-      }
+      expect(sierraUser.status).toBe(ResponseStatus.Success);
+      const storedPatron = (sierraUser as SuccessResponse<PatronRecord>).result;
+
+      expect(storedPatron.firstName).toBe(firstName);
+      expect(storedPatron.lastName).toBe(lastName);
     });
 
     it('409s if a user is already registered', async () => {
@@ -80,12 +80,11 @@ describe('/users/{userId}/registration', () => {
         testUser.userId
       );
 
-      if (sierraUser.status === ResponseStatus.Success) {
-        expect(sierraUser.result.firstName).toBe('Henry');
-        expect(sierraUser.result.lastName).toBe('Wellcome');
-      } else {
-        throw new Error(`Unexpected failure from Sierra: ${sierraUser}`);
-      }
+      expect(sierraUser.status).toBe(ResponseStatus.Success);
+      const storedPatron = (sierraUser as SuccessResponse<PatronRecord>).result;
+
+      expect(storedPatron.firstName).toBe('Henry');
+      expect(storedPatron.lastName).toBe('Wellcome');
     });
 
     it('404s for users that do not exist', async () => {

--- a/packages/apps/api/test/routes/users_user_id_registration.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_registration.test.ts
@@ -7,7 +7,10 @@ describe('/users/{userId}/registration', () => {
     it('changes the name in Sierra', async () => {
       const firstName = 'Jane';
       const lastName = 'Smith';
-      const testUser = randomExistingUser({ firstName: 'Auth0_Registration_undefined', lastName: 'Auth0_Registration_tempLastName' });
+      const testUser = randomExistingUser({
+        firstName: 'Auth0_Registration_undefined',
+        lastName: 'Auth0_Registration_tempLastName',
+      });
       const { api, clients } = mockedApi([testUser]);
 
       const response = await withCallerId('@machine')(
@@ -25,6 +28,58 @@ describe('/users/{userId}/registration', () => {
       if (sierraUser.status === ResponseStatus.Success) {
         expect(sierraUser.result.firstName).toBe(firstName);
         expect(sierraUser.result.lastName).toBe(lastName);
+      } else {
+        throw new Error(`Unexpected failure from Sierra: ${sierraUser}`);
+      }
+    });
+
+    it('returns a 204 if the name in Sierra is already correct', async () => {
+      const firstName = 'Joe';
+      const lastName = 'Bloggs';
+      const testUser = randomExistingUser({ firstName, lastName });
+      const { api, clients } = mockedApi([testUser]);
+
+      const response = await withCallerId('@machine')(
+        api
+          .put(`/users/${testUser.userId}/registration`)
+          .send({ firstName, lastName })
+      );
+
+      expect(response.statusCode).toBe(204);
+
+      const sierraUser = await clients.sierra.getPatronRecordByRecordNumber(
+        testUser.userId
+      );
+
+      if (sierraUser.status === ResponseStatus.Success) {
+        expect(sierraUser.result.firstName).toBe(firstName);
+        expect(sierraUser.result.lastName).toBe(lastName);
+      } else {
+        throw new Error(`Unexpected failure from Sierra: ${sierraUser}`);
+      }
+    });
+
+    it('400s if a user is already registered', async () => {
+      const firstName = 'Silas';
+      const lastName = 'Burroughs';
+      const testUser = randomExistingUser({ firstName: 'Henry', lastName: 'Wellcome' });
+      const { api, clients } = mockedApi([testUser]);
+
+      const response = await withCallerId('@machine')(
+        api
+          .put(`/users/${testUser.userId}/registration`)
+          .send({ firstName, lastName })
+      );
+
+      expect(response.statusCode).toBe(400);
+
+      const sierraUser = await clients.sierra.getPatronRecordByRecordNumber(
+        testUser.userId
+      );
+
+      if (sierraUser.status === ResponseStatus.Success) {
+        expect(sierraUser.result.firstName).toBe('Henry');
+        expect(sierraUser.result.lastName).toBe('Wellcome');
       } else {
         throw new Error(`Unexpected failure from Sierra: ${sierraUser}`);
       }

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -2,5 +2,5 @@ import SierraClient from './SierraClient';
 import HttpSierraClient from './HttpSierraClient';
 import MockSierraClient from './MockSierraClient';
 
-export { PatronRecord, varFieldTags } from './patron';
+export { PatronRecord, Role, varFieldTags } from './patron';
 export { HttpSierraClient, MockSierraClient, SierraClient };

--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -28,7 +28,7 @@ export function getVarFieldContent(
 // Sierra stores the names of Patron records in two formats: MARC and non-MARC. In the former, names are represented as
 // a JSON object, where each part of the name (first name, last name) is represented as a sub-object on its own. In the
 // case of non-MARC, it's a single string value with various prefixes.
-function getPatronName(varFields: VarField[]): {
+export function getPatronName(varFields: VarField[]): {
   firstName: string;
   lastName: string;
 } {

--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -205,7 +205,7 @@ export type VarField = {
 export type UpdateOptions = {
   pin?: string;
   barcodes?: [barcode: string];
-  varFields?: VarField;
+  varFields?: VarField[];
 };
 
 type SubField = {


### PR DESCRIPTION
Closes #347

Inside the `PUT /users/{userId}/registration` endpoint, we now retrieve the existing patron record from Sierra before updating the first/last name.

This gives us some additional security on this endpoint: in particular, we'll reject updates for a patron if they don't have our Auth0 placeholder name `Auth0_Registration_undefined Auth0_Registration_tempLastName`.

This is the intended logic:

```mermaid
flowchart TD
    GET{get patron<br/>from Sierra}

    GET -- does not exist --> E404[HTTP 404<br/>Not Found]
    GET -- other error --> E500[HTTP 500<br/>Internal Server Error]

    GET --> MATCH{does stored<br/>name match<br/>the request?}

    MATCH -- yes --> NOOP[no-op]
    MATCH -- no --> PLACE{is stored name<br/>the placeholder?}
    
    PLACE -- yes --> UPDATE[update name in Sierra<br/>HTTP 204 No Content]
    PLACE -- no --> E409[HTTP 409 Conflict]
    

    classDef decisionNode fill:#e8e8e8,stroke:#8f8f8f
    class GET,PLACE,MATCH decisionNode

    classDef errorNode fill:#f8c4c9,stroke:#e01b2f,stroke-width:2px
    class E404,E500,E409 errorNode

    classDef successNode fill:#d1ffe9,stroke:#007868,stroke-width:2px
    class NOOP,UPDATE successNode
```

I've also changed how the UpdateUser process works slightly:

* We can't update the name in Auth0 and I don't think we need to, so we don't
* We need to send a list of varfields to Sierra, not a single one