### PR TITLE
Remove the redirect to the /success endpoint

### DIFF
--- a/packages/apps/auth0-actions/src/redirect_to_full_registration.ts
+++ b/packages/apps/auth0-actions/src/redirect_to_full_registration.ts
@@ -57,14 +57,6 @@ export const onContinuePostLogin = async (
   event: Event<Auth0User>,
   api: API<Auth0User>
 ) => {
-  const SUCCESS_URL = `${event.secrets.IDENTITY_APP_BASEURL}/success`;
-
-  // Once the full registration form has been submitted, it is signed with JWT handler on Identity App (Weco)
-  // This jwt token is sent back to /continue on auth0 actions, and we validate/decode the token to get formData
-  // On success of full registration form submission at Identity API updateUserAfterRegistration endpoint
-  // we redirect to /continue with encoded formData from the endpoint
-  // any data we send to /continue is tokenized and validated below
-
   try {
     const payload = api.redirect.validateToken({
       secret: event.secrets.AUTH0_PAYLOAD_SECRET,
@@ -75,7 +67,6 @@ export const onContinuePostLogin = async (
       'terms_and_conditions_accepted',
       Boolean(payload.terms_and_conditions_accepted)
     );
-    api.redirect.sendUserTo(SUCCESS_URL, { query: { success: 'true' } });
   } catch (error) {
     console.error(error, 'Validation of redirect token failed');
   }

--- a/packages/apps/auth0-actions/tests/redirect_to_full_registration.test.ts
+++ b/packages/apps/auth0-actions/tests/redirect_to_full_registration.test.ts
@@ -120,10 +120,6 @@ describe('redirect_to_full_registration', () => {
     const payload = { terms_and_conditions_accepted: true };
     onContinuePostLogin(continueNewUserEvent(user), mockPostLoginApi);
     expect(mockPostLoginApi.redirect.validateToken).toReturnWith(payload);
-    expect(mockPostLoginApi.redirect.sendUserTo).toHaveBeenLastCalledWith(
-      successUrl,
-      { query: { success: 'true' } }
-    );
   });
 });
 


### PR DESCRIPTION
Currently this interrupts the login flow, and takes the user to a `wc.org/account/success`, where they aren't logged in and don't have a valid session.

It's not obvious how we can redirect to that page and give them a valid session, so for now we're going to remove the `/success` page from the flow and send somebody straight to their account page.  This is simpler and means we're pretty close to having a working end-to-end flow.