### PR TITLE
Allow sending somebody to the /success URL after logging out

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -200,6 +200,7 @@ resource "auth0_client" "account_management_system" {
 
   grant_types = [
     "authorization_code",
+    "client_credentials",
     "refresh_token"
   ]
 
@@ -209,6 +210,7 @@ resource "auth0_client" "account_management_system" {
 
   allowed_logout_urls = [
     local.wellcome_collection_site_uri,
+    "${local.wellcome_collection_site_uri}/account/success",
     local.ams_delete_requested_uri
   ]
 

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -173,7 +173,9 @@ resource "auth0_client_grant" "buildkite" {
 # Lets the Account Management System component initialise and process OAuth 2.0 / OIDC login requests through Auth0
 
 resource "auth0_client" "account_management_system" {
-  name                 = "Account Management System${local.environment_qualifier}"
+  name        = "Account Management System${local.environment_qualifier}"
+  description = "The identity web app, as defined in the wellcomecollection.org repo"
+
   app_type             = "regular_web"
   is_first_party       = true
   custom_login_page_on = true


### PR DESCRIPTION
This is already applied in staging.

For https://github.com/wellcomecollection/wellcomecollection.org/pull/8119

Without it, you get an error:

<img width="791" alt="Screenshot 2022-07-01 at 11 58 39" src="https://user-images.githubusercontent.com/301220/176881849-9c7b02ce-274f-42c4-b684-741da22b523d.png">

