### PR TITLE
Always fetch the createdDate of a patron from Sierra

### DIFF
--- a/packages/apps/api/test/routes/fixtures/mockedApi.ts
+++ b/packages/apps/api/test/routes/fixtures/mockedApi.ts
@@ -68,6 +68,7 @@ export const mockedApi = (existingUsers: ExistingUser[] = []) => {
         lastName: user.lastName,
         email: user.email,
         role: user.role ?? 'Reader',
+        createdDate: new Date(),
       },
       user.password
     );

--- a/packages/apps/auth0-database-scripts/tests/login.test.ts
+++ b/packages/apps/auth0-database-scripts/tests/login.test.ts
@@ -23,6 +23,7 @@ const testPatronRecord: PatronRecord = {
   email: 'test@test.test',
   role: 'Reader',
   verifiedEmail: 'test@test.test',
+  createdDate: new Date('2001-01-01T01:01:01Z'),
 };
 
 const testPatronPassword = 'super-secret';

--- a/packages/apps/auth0-database-scripts/tests/patronRecordToUser.test.ts
+++ b/packages/apps/auth0-database-scripts/tests/patronRecordToUser.test.ts
@@ -9,6 +9,7 @@ const testPatronRecord: PatronRecord = {
   email: 'test@test.test',
   role: 'Reader',
   verifiedEmail: 'test@test.test',
+  createdDate: new Date('2001-01-01T01:01:01Z'),
 };
 
 describe('patronRecordToUser', () => {

--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -13,7 +13,6 @@ import {
   PatronCreateResponse,
   toPatronRecord,
   varFieldTags,
-  VarField,
   UpdateOptions,
 } from './patron';
 import SierraClient from './SierraClient';

--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -22,7 +22,7 @@ import {
 } from './email-verification-notes';
 import { paginatedSierraResults } from './pagination';
 
-const minimumPatronFields = ['varFields', 'patronType'];
+const minimumPatronFields = ['varFields', 'patronType', 'createdDate'];
 
 export default class HttpSierraClient implements SierraClient {
   private readonly apiRoot: string;

--- a/packages/shared/sierra-client/src/MockSierraClient.ts
+++ b/packages/shared/sierra-client/src/MockSierraClient.ts
@@ -43,6 +43,7 @@ export default class MockSierraClient implements SierraClient {
     lastName: lastName ?? 'Patron',
     email: 'test' + Math.floor(Math.random() * 100).toString() + '@patron',
     role: role ?? 'Reader',
+    createdDate: new Date(),
   });
 
   getPatronRecordByEmail = jest.fn(async (email: string) => {
@@ -156,6 +157,7 @@ export default class MockSierraClient implements SierraClient {
         lastName,
         email,
         role: role ?? 'Reader',
+        createdDate: new Date(),
       });
 
       this.addPatron(newPatronRecord('Ravi', 'Ravioli', 'SelfRegistered'));

--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -12,6 +12,7 @@ export function toPatronRecord(response: PatronResponse): PatronRecord {
     role: patronTypeToRole(response.patronType),
     email: patronEmail,
     verifiedEmail: verifiedEmail(response.varFields),
+    createdDate: new Date(response.createdDate),
   };
 }
 
@@ -157,6 +158,7 @@ export type PatronRecord = {
   email: string;
   role: Role;
   verifiedEmail?: string;
+  createdDate: Date;
 };
 
 export type PatronCreateResponse = {
@@ -168,6 +170,7 @@ export type PatronResponse = {
   patronType: number;
   deleted: boolean;
   varFields: VarField[];
+  createdDate: string;
 };
 
 // This represents the data required to create a Patron record in Sierra. The 'fixedFields' a bit odd, as the keys of

--- a/packages/shared/sierra-client/tests/http-sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/http-sierra-client.test.ts
@@ -3,6 +3,7 @@ import { PatronRecord, HttpSierraClient } from '../src';
 import mockSierraServer, { apiRoot, routeUrls } from './mock-sierra-server';
 import {
   barcode,
+  createdDate,
   email,
   firstName,
   lastName,
@@ -188,6 +189,7 @@ describe('HTTP sierra client', () => {
         recordNumber,
         role,
         verifiedEmail,
+        createdDate: new Date(createdDate),
       });
     });
 
@@ -204,6 +206,7 @@ describe('HTTP sierra client', () => {
         recordNumber,
         role,
         verifiedEmail,
+        createdDate: new Date(createdDate),
       });
     });
 
@@ -257,6 +260,7 @@ describe('HTTP sierra client', () => {
         recordNumber,
         role,
         verifiedEmail,
+        createdDate: new Date(createdDate),
       });
     });
 
@@ -273,6 +277,7 @@ describe('HTTP sierra client', () => {
         recordNumber,
         role,
         verifiedEmail,
+        createdDate: new Date(createdDate),
       });
     });
 
@@ -309,6 +314,7 @@ describe('HTTP sierra client', () => {
         recordNumber,
         role,
         verifiedEmail: email,
+        createdDate: new Date(createdDate),
       });
     });
 
@@ -336,6 +342,7 @@ describe('HTTP sierra client', () => {
         recordNumber,
         role,
         verifiedEmail,
+        createdDate: new Date(createdDate),
       });
     });
 

--- a/packages/shared/sierra-client/tests/mock-sierra-server.ts
+++ b/packages/shared/sierra-client/tests/mock-sierra-server.ts
@@ -53,7 +53,7 @@ const handlers = [
       ...(req.url.searchParams.get('fields')?.split(',') || []),
     ];
     const response = Object.fromEntries(
-      fields.map((field) => [field, recordMarc[field]])
+      fields.map((field) => [field, (recordMarc as any)[field]])
     );
     return res(ctx.json(response));
   }),

--- a/packages/shared/sierra-client/tests/patron.test.ts
+++ b/packages/shared/sierra-client/tests/patron.test.ts
@@ -39,6 +39,45 @@ describe('toPatronRecord', () => {
     expect(result.lastName).toEqual('Wellcome');
   });
 
+  it('gets the createdDate of the user', () => {
+    const recordMarc: PatronResponse = {
+      id: 123456,
+      patronType: 7,
+      deleted: false,
+      varFields: [
+        {
+          fieldTag: 'b',
+          content: '1234567',
+        },
+        {
+          fieldTag: 'z',
+          content: 'h.wellcome@wellcome.org',
+        },
+        {
+          fieldTag: 'n',
+          marcTag: '100',
+          ind1: ' ',
+          ind2: ' ',
+          subfields: [
+            {
+              tag: 'a',
+              content: 'Wellcome',
+            },
+            {
+              tag: 'b',
+              content: 'Henry',
+            },
+          ],
+        },
+      ],
+      createdDate: '2022-06-21T15:37:32Z',
+    };
+
+    const result = toPatronRecord(recordMarc);
+
+    expect(result.createdDate).toEqual(new Date('2022-06-21T15:37:32Z'));
+  });
+
   it('strips the trailing comma from names', () => {
     const recordMarc: PatronResponse = {
       id: 1101796,
@@ -75,6 +114,7 @@ describe('toPatronRecord', () => {
           ],
         },
       ],
+      createdDate: '2022-06-21T15:37:32Z',
     };
 
     const result = toPatronRecord(recordMarc);
@@ -113,6 +153,7 @@ describe('toPatronRecord', () => {
         ],
       },
     ],
+    createdDate: '2022-06-21T15:37:32Z',
   });
 
   test.each([

--- a/packages/shared/sierra-client/tests/test-patron.ts
+++ b/packages/shared/sierra-client/tests/test-patron.ts
@@ -1,3 +1,5 @@
+import { PatronResponse } from './patron';
+
 export const recordNumber: number = 123456;
 export const barcode: string = '654321';
 export const pin: string = 'superstrongpassword';
@@ -6,8 +8,9 @@ export const lastName: string = 'User';
 export const email: string = 'test.user@example.com';
 export const role: string = 'Reader';
 export const verifiedEmail: string | undefined = undefined;
+export const createdDate: string = '2001-01-01T01:01:01Z';
 
-export const recordMarc: any = {
+export const recordMarc: PatronResponse = {
   id: 123456,
   deleted: false,
   patronType: 7,
@@ -37,9 +40,10 @@ export const recordMarc: any = {
       ],
     },
   ],
+  createdDate,
 };
 
-export const recordNonMarc: any = {
+export const recordNonMarc: PatronResponse = {
   id: 123456,
   patronType: 7,
   deleted: false,
@@ -57,4 +61,5 @@ export const recordNonMarc: any = {
       content: 'a|' + lastName + ', |b' + firstName,
     },
   ],
+  createdDate,
 };


### PR DESCRIPTION
We're going to use this to detect whether a user pre-dates the current sign-up process, and if so, skip implicit email verification.

This patch just fetches the `createdDate` field from Sierra; the next patch will actually use it.