### PR TITLE
Don't say "Hi, Auth0_Registration_undefined" in emails

### DIFF
--- a/universal_login/emails/blocked_account.html
+++ b/universal_login/emails/blocked_account.html
@@ -26,6 +26,7 @@
                 margin: 20px 0;
               "
             ></div>
+            {% if user.given_name != 'Auth0_Registration_undefined' %}
             <p
               style="
                 margin-bottom: 1.3em;
@@ -37,6 +38,7 @@
             >
               Hi {{user.given_name}},
             </p>
+            {% endif %}
             <p
               style="
                 margin-bottom: 1.3em;

--- a/universal_login/emails/reset_email.html
+++ b/universal_login/emails/reset_email.html
@@ -26,6 +26,7 @@
                 margin: 20px 0;
               "
             ></div>
+            {% if user.given_name != 'Auth0_Registration_undefined' %}
             <p
               style="
                 margin-bottom: 1.3em;
@@ -37,6 +38,7 @@
             >
               Hi {{user.given_name}},
             </p>
+            {% endif %}
             <p
               style="
                 margin-bottom: 1.3em;

--- a/universal_login/emails/verify_email.html
+++ b/universal_login/emails/verify_email.html
@@ -26,6 +26,7 @@
                 margin: 20px 0;
               "
             ></div>
+            {% if user.given_name != 'Auth0_Registration_undefined' %}
             <p
               style="
                 margin-bottom: 1.3em;
@@ -37,6 +38,7 @@
             >
               Hi {{user.given_name}},
             </p>
+            {% endif %}
             <p
               style="
                 margin-bottom: 1.3em;

--- a/universal_login/emails/welcome_email.html
+++ b/universal_login/emails/welcome_email.html
@@ -26,6 +26,7 @@
                 margin: 20px 0;
               "
             ></div>
+            {% if user.given_name != 'Auth0_Registration_undefined' %}
             <p
               style="
                 margin-bottom: 1.3em;
@@ -37,6 +38,7 @@
             >
               Hi {{user.given_name}},
             </p>
+            {% endif %}
             <p
               style="
                 margin-bottom: 1.3em;


### PR DESCRIPTION
If a user gets an email before they've set their name (for example, the initial email asking them to verify), we don't want to expose the placeholder name from the sign-up process.

In these cases, skip the greeting entirely.