### PR TITLE
Don't hide the alternate action on prod

### DIFF
--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -335,13 +335,5 @@
         {% endif %}
       </div>
     </div>
-    <script type="text/javascript">
-      var alternateAction = document.querySelector('._alternate-action');
-      var isStage = window.location.host.includes('stage');
-
-      if (isStage && alternateAction) {
-        alternateAction.style.display = 'block';
-      }
-    </script>
   </body>
 </html>


### PR DESCRIPTION
This is a somewhat hacky thing we did to prevent the sign-up links appearing outside staging; now we're ready to make sign-up live, we can remove it.