### PR TITLE
Add a helper for creating the varField for a name

### DIFF
--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -5,8 +5,7 @@ import { toMessage } from '../models/common';
 import { clientResponseToHttpError, HttpError } from '../models/HttpError';
 import { toUser } from '../models/user';
 import { EmailClient } from '../utils/EmailClient';
-import { SierraClient } from '@weco/sierra-client';
-import { createNameVarField } from 'sierra-client/src/marc';
+import { createNameVarField, SierraClient } from '@weco/sierra-client';
 
 export function validatePassword(auth0Client: Auth0Client) {
   const checkPassword = passwordCheckerForUser(auth0Client);

--- a/packages/apps/api/src/handlers/user.ts
+++ b/packages/apps/api/src/handlers/user.ts
@@ -5,7 +5,8 @@ import { toMessage } from '../models/common';
 import { clientResponseToHttpError, HttpError } from '../models/HttpError';
 import { toUser } from '../models/user';
 import { EmailClient } from '../utils/EmailClient';
-import { SierraClient, varFieldTags } from '@weco/sierra-client';
+import { SierraClient } from '@weco/sierra-client';
+import { createNameVarField } from 'sierra-client/src/marc';
 
 export function validatePassword(auth0Client: Auth0Client) {
   const checkPassword = passwordCheckerForUser(auth0Client);
@@ -118,27 +119,7 @@ export function updateUserAfterRegistration(sierraClient: SierraClient) {
     // log the user out after they complete the sign-up process.  When they log back in,
     // Auth0 will re-fetch their profile data from Sierra.
     const updatePatronResponse = await sierraClient.updatePatron(userId, {
-      varFields: [
-        {
-          fieldTag: varFieldTags.name,
-          subfields: [
-            // The trailing comma allows the MARC values to be concatenated into one string:
-            //
-            //         Smith, |cDr |bJane
-            //      => Smith, Dr Jane
-            //
-            // This also mirrors patron records that were created in the previous system.
-            {
-              tag: 'a',
-              content: `${lastName},`,
-            },
-            {
-              tag: 'b',
-              content: firstName,
-            },
-          ],
-        },
-      ],
+      varFields: [createNameVarField({ firstName, lastName })],
     });
     if (updatePatronResponse.status !== ResponseStatus.Success) {
       throw clientResponseToHttpError(updatePatronResponse);

--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -21,6 +21,7 @@ import {
   NoteOptions,
 } from './email-verification-notes';
 import { paginatedSierraResults } from './pagination';
+import { createNameVarField } from './marc';
 
 const minimumPatronFields = ['varFields', 'patronType', 'createdDate'];
 
@@ -126,22 +127,7 @@ export default class HttpSierraClient implements SierraClient {
               268: { label: 'Notice Preference', value: 'z' },
             },
             varFields: [
-              {
-                fieldTag: varFieldTags.name,
-                marcTag: '100',
-                ind1: ' ',
-                ind2: ' ',
-                subfields: [
-                  {
-                    tag: 'a',
-                    content: lastName,
-                  },
-                  {
-                    tag: 'b',
-                    content: firstName,
-                  },
-                ],
-              },
+              createNameVarField({ firstName, lastName }),
               {
                 fieldTag: 'z',
                 content: email.toLocaleLowerCase(),

--- a/packages/shared/sierra-client/src/index.ts
+++ b/packages/shared/sierra-client/src/index.ts
@@ -3,5 +3,5 @@ import HttpSierraClient from './HttpSierraClient';
 import MockSierraClient from './MockSierraClient';
 
 export { PatronRecord, Role } from './patron';
-export { varFieldTags } from './marc';
+export { createNameVarField, varFieldTags } from './marc';
 export { HttpSierraClient, MockSierraClient, SierraClient };

--- a/packages/shared/sierra-client/src/marc/index.ts
+++ b/packages/shared/sierra-client/src/marc/index.ts
@@ -1,2 +1,2 @@
 export { getVarFieldContent, SubField, VarField, varFieldTags } from './fields';
-export { getPatronName } from './names';
+export { createNameVarField, getPatronName } from './names';

--- a/packages/shared/sierra-client/src/marc/names.ts
+++ b/packages/shared/sierra-client/src/marc/names.ts
@@ -5,6 +5,29 @@ type Name = {
   lastName: string;
 };
 
+export function createNameVarField({ firstName, lastName }: Name): VarField {
+  return {
+    fieldTag: varFieldTags.name,
+    marcTag: '100',
+    subfields: [
+      // The trailing comma allows the MARC values to be concatenated into one string:
+      //
+      //         Smith, |cDr |bJane
+      //      => Smith, Dr Jane
+      //
+      // This also mirrors patron records that were created in the previous system.
+      {
+        tag: 'a',
+        content: `${lastName},`,
+      },
+      {
+        tag: 'b',
+        content: firstName,
+      },
+    ],
+  };
+}
+
 // Sierra stores the names of Patron records in two formats: MARC and non-MARC. In the former, names are represented as
 // a JSON object, where each part of the name (first name, last name) is represented as a sub-object on its own. In the
 // case of non-MARC, it's a single string value with various prefixes.

--- a/packages/shared/sierra-client/tests/marc/names.test.ts
+++ b/packages/shared/sierra-client/tests/marc/names.test.ts
@@ -1,4 +1,8 @@
-import { getPatronName, varFieldTags } from '../../src/marc';
+import {
+  createNameVarField,
+  getPatronName,
+  varFieldTags,
+} from '../../src/marc';
 
 // The initial set of tests for this method was created by fetching every
 // patron record in Sierra, and writing new tests until there was one for
@@ -114,5 +118,27 @@ describe('getPatronName', () => {
       expect(name.firstName).toBe('Virginia Apgar');
       expect(name.lastName).toBe('');
     });
+  });
+});
+
+describe('createNameVarField', () => {
+  const varField = createNameVarField({
+    firstName: 'Ogino',
+    lastName: 'Ginko',
+  });
+
+  expect(varField).toStrictEqual({
+    fieldTag: 'n',
+    marcTag: '100',
+    subfields: [
+      {
+        content: 'Ginko,',
+        tag: 'a',
+      },
+      {
+        content: 'Ogino',
+        tag: 'b',
+      },
+    ],
   });
 });


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8207; follows #363

Previously we had two slightly divergent implementations for creating a name varfield:

* When we create a user, we'd set field tag `n`, MARC tag 100 and subfields $a and $b
* When we updated a user, we'd set field tag `n` and subfields $a and $b, but no MARC tag 100

I think the omission of MARC tag 100 is causing us issues – e.g. in the Sierra GUI, a name without it is treated as opaque text rather than a structured MARC field.

This patch introduces a single implementation `createNameVarField()` which is used in both places, and gives us consistent behaviour.