### PR TITLE
Fix some deployment issues

### DIFF
--- a/infra/modules/route/methods.tf
+++ b/infra/modules/route/methods.tf
@@ -42,7 +42,17 @@ resource "aws_api_gateway_method_response" "options" {
 
   rest_api_id = var.rest_api_id
   resource_id = aws_api_gateway_resource.resource.id
-  http_method = "OPTIONS"
+
+  # Note: this has the side effect of ensuring the method resource
+  # is created before the method response resource.
+  #
+  # If you hard-code the method here, you may get an error:
+  #
+  #     Error creating API Gateway Integration: NotFoundException:
+  #     Invalid Method identifier specified
+  #
+  # I think ensuring the method is created first resolves it.
+  http_method = aws_api_gateway_method.options[0].http_method
 
   status_code = each.key
 
@@ -80,7 +90,17 @@ resource "aws_api_gateway_method_response" "get_success" {
 
   rest_api_id = var.rest_api_id
   resource_id = aws_api_gateway_resource.resource.id
-  http_method = "GET"
+
+  # Note: this has the side effect of ensuring the method resource
+  # is created before the method response resource.
+  #
+  # If you hard-code the method here, you may get an error:
+  #
+  #     Error creating API Gateway Integration: NotFoundException:
+  #     Invalid Method identifier specified
+  #
+  # I think ensuring the method is created first resolves it.
+  http_method = aws_api_gateway_method.get[0].http_method
 
   status_code = each.key
 
@@ -130,7 +150,17 @@ resource "aws_api_gateway_method_response" "put_success" {
 
   rest_api_id = var.rest_api_id
   resource_id = aws_api_gateway_resource.resource.id
-  http_method = "PUT"
+
+  # Note: this has the side effect of ensuring the method resource
+  # is created before the method response resource.
+  #
+  # If you hard-code the method here, you may get an error:
+  #
+  #     Error creating API Gateway Integration: NotFoundException:
+  #     Invalid Method identifier specified
+  #
+  # I think ensuring the method is created first resolves it.
+  http_method = aws_api_gateway_method.put[0].http_method
 
   status_code = each.key
 
@@ -181,7 +211,17 @@ resource "aws_api_gateway_method_response" "post_success" {
 
   rest_api_id = var.rest_api_id
   resource_id = aws_api_gateway_resource.resource.id
-  http_method = "POST"
+
+  # Note: this has the side effect of ensuring the method resource
+  # is created before the method response resource.
+  #
+  # If you hard-code the method here, you may get an error:
+  #
+  #     Error creating API Gateway Integration: NotFoundException:
+  #     Invalid Method identifier specified
+  #
+  # I think ensuring the method is created first resolves it.
+  http_method = aws_api_gateway_method.post[0].http_method
 
   status_code = each.key
 

--- a/infra/scoped/api-gateway.tf
+++ b/infra/scoped/api-gateway.tf
@@ -70,8 +70,8 @@ locals {
       }
     }
 
-    "/users/:user_id/send_verification_email" = {
-      path_part = "send_verification_email"
+    "/users/:user_id/send-verification-email" = {
+      path_part = "send-verification-email"
 
       responses = {
         OPTIONS = ["204"]

--- a/packages/apps/api-authorizer/src/handler.ts
+++ b/packages/apps/api-authorizer/src/handler.ts
@@ -34,7 +34,7 @@ const validateRequest = resourceAuthorizationValidator({
   '/users/{userId}/deletion-request': {
     PUT: allOf(isSelf, hasScopes('delete:patron')),
   },
-  '/users/{userId}/send_verification': {
+  '/users/{userId}/send-verification-email': {
     POST: allOf(isSelf, hasScopes('update:user')),
   },
   '/users/{userId}/validate': {

--- a/packages/apps/api/src/app.ts
+++ b/packages/apps/api/src/app.ts
@@ -139,9 +139,9 @@ function registerUsersUserSendEmailVerificationResource(
     methods: 'OPTIONS,POST',
     origin: process.env.API_ALLOWED_ORIGINS,
   });
-  app.options('/users/:user_id/send_verification', corsOptions);
+  app.options('/users/:user_id/send-verification-email', corsOptions);
   app.post(
-    '/users/:user_id/send_verification',
+    '/users/:user_id/send-verification-email',
     corsOptions,
     asyncHandler(sendVerificationEmail(clients.auth0))
   );

--- a/packages/apps/api/test/routes/users_user_id_send_verification_email.test.ts
+++ b/packages/apps/api/test/routes/users_user_id_send_verification_email.test.ts
@@ -1,12 +1,12 @@
 import { mockedApi, withCallerId } from './fixtures/mockedApi';
 import { randomAlphanumeric, randomExistingUser } from './fixtures/generators';
 
-describe('POST /users/{userId}/send_verification', () => {
+describe('POST /users/{userId}/send-verification-email', () => {
   it('sends a verification email for an existing user', async () => {
     const testUser = randomExistingUser({ password: randomAlphanumeric(10) });
     const { api, clients } = mockedApi([testUser]);
     const response = await withCallerId(testUser.userId)(
-      api.post(`/users/${testUser.userId}/send_verification`)
+      api.post(`/users/${testUser.userId}/send-verification-email`)
     );
 
     expect(response.statusCode).toBe(204);
@@ -19,7 +19,7 @@ describe('POST /users/{userId}/send_verification', () => {
     const { api, clients } = mockedApi();
     const id = 1234567;
     const response = await withCallerId(id)(
-      api.post(`/users/${id}/send_verification`)
+      api.post(`/users/${id}/send-verification-email`)
     );
 
     expect(response.statusCode).toBe(404);


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8179

* Fix a Terraform issue where the `method` has to be created before the `method_response`; some hard-coding of the HTTP method as strings I did in #366 broke this ordering, but because I was only dealing with already-existing resources I didn't realise.
* Make the endpoint name consistent as `/send-verification-email`