### PR TITLE
Remove some of the 'account management system' naming

### DIFF
--- a/infra/modules/route/methods.tf
+++ b/infra/modules/route/methods.tf
@@ -114,7 +114,17 @@ resource "aws_api_gateway_method_response" "get_errors" {
 
   rest_api_id = var.rest_api_id
   resource_id = aws_api_gateway_resource.resource.id
-  http_method = "GET"
+
+  # Note: this has the side effect of ensuring the method resource
+  # is created before the method response resource.
+  #
+  # If you hard-code the method here, you may get an error:
+  #
+  #     Error creating API Gateway Integration: NotFoundException:
+  #     Invalid Method identifier specified
+  #
+  # I think ensuring the method is created first resolves it.
+  http_method = aws_api_gateway_method.get[0].http_method
 
   status_code = each.key
 
@@ -174,7 +184,17 @@ resource "aws_api_gateway_method_response" "put_errors" {
 
   rest_api_id = var.rest_api_id
   resource_id = aws_api_gateway_resource.resource.id
-  http_method = "PUT"
+
+  # Note: this has the side effect of ensuring the method resource
+  # is created before the method response resource.
+  #
+  # If you hard-code the method here, you may get an error:
+  #
+  #     Error creating API Gateway Integration: NotFoundException:
+  #     Invalid Method identifier specified
+  #
+  # I think ensuring the method is created first resolves it.
+  http_method = aws_api_gateway_method.put[0].http_method
 
   status_code = each.key
 
@@ -239,7 +259,17 @@ resource "aws_api_gateway_method_response" "post_errors" {
 
   rest_api_id = var.rest_api_id
   resource_id = aws_api_gateway_resource.resource.id
-  http_method = "POST"
+
+  # Note: this has the side effect of ensuring the method resource
+  # is created before the method response resource.
+  #
+  # If you hard-code the method here, you may get an error:
+  #
+  #     Error creating API Gateway Integration: NotFoundException:
+  #     Invalid Method identifier specified
+  #
+  # I think ensuring the method is created first resolves it.
+  http_method = aws_api_gateway_method.post[0].http_method
 
   status_code = each.key
 

--- a/infra/scoped/api-key.tf
+++ b/infra/scoped/api-key.tf
@@ -38,18 +38,28 @@ resource "aws_api_gateway_usage_plan_key" "dummy" {
   key_type      = "API_KEY"
 }
 
-# Account Management System
+# Identity web app
 
-resource "aws_api_gateway_api_key" "account_management_system" {
-  name = "account management system"
+moved {
+  from = aws_api_gateway_api_key.account_management_system
+  to   = aws_api_gateway_api_key.identity_web_app
+}
+
+resource "aws_api_gateway_api_key" "identity_web_app" {
+  name = "identity web app${local.environment_qualifier}"
 
   tags = {
-    "Name" = "account management system"
+    "Name" = "identity web app"
   }
 }
 
-resource "aws_api_gateway_usage_plan_key" "account_management_system" {
-  key_id        = aws_api_gateway_api_key.account_management_system.id
+moved {
+  from = aws_api_gateway_usage_plan_key.account_management_system
+  to   = aws_api_gateway_usage_plan_key.identity_web_app
+}
+
+resource "aws_api_gateway_usage_plan_key" "identity_web_app" {
+  key_id        = aws_api_gateway_api_key.identity_web_app.id
   usage_plan_id = aws_api_gateway_usage_plan.basic.id
   key_type      = "API_KEY"
 }

--- a/infra/scoped/api-key.tf
+++ b/infra/scoped/api-key.tf
@@ -40,22 +40,12 @@ resource "aws_api_gateway_usage_plan_key" "dummy" {
 
 # Identity web app
 
-moved {
-  from = aws_api_gateway_api_key.account_management_system
-  to   = aws_api_gateway_api_key.identity_web_app
-}
-
 resource "aws_api_gateway_api_key" "identity_web_app" {
   name = "identity web app${local.environment_qualifier}"
 
   tags = {
     "Name" = "identity web app"
   }
-}
-
-moved {
-  from = aws_api_gateway_usage_plan_key.account_management_system
-  to   = aws_api_gateway_usage_plan_key.identity_web_app
 }
 
 resource "aws_api_gateway_usage_plan_key" "identity_web_app" {

--- a/infra/scoped/auth0-actions.tf
+++ b/infra/scoped/auth0-actions.tf
@@ -44,7 +44,7 @@ resource "auth0_action" "redirect_to_full_registration" {
   # time to debug this properly.
   secrets {
     name  = "IDENTITY_APP_BASEURL"
-    value = local.ams_registration_uri
+    value = local.front_end_registration_uri
   }
 
   secrets {

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -172,8 +172,13 @@ resource "auth0_client_grant" "buildkite" {
 # Account Management System
 # Lets the Account Management System component initialise and process OAuth 2.0 / OIDC login requests through Auth0
 
-resource "auth0_client" "account_management_system" {
-  name        = "Account Management System${local.environment_qualifier}"
+moved {
+  from = auth0_client.account_management_system
+  to   = auth0_client.identity_web_app
+}
+
+resource "auth0_client" "identity_web_app" {
+  name        = "Identity web app${local.environment_qualifier}"
   description = "The identity web app, as defined in the wellcomecollection.org repo"
 
   app_type             = "regular_web"
@@ -224,7 +229,7 @@ resource "auth0_client" "account_management_system" {
 }
 
 resource "auth0_client_grant" "account_management_system" {
-  client_id = auth0_client.account_management_system.client_id
+  client_id = auth0_client.identity_web_app.client_id
   audience  = auth0_resource_server.identity_api.identifier
 
   // Be explicit about these scopes so as not to accidentally give too many permissions

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -169,13 +169,8 @@ resource "auth0_client_grant" "buildkite" {
   ]
 }
 
-# Account Management System
-# Lets the Account Management System component initialise and process OAuth 2.0 / OIDC login requests through Auth0
-
-moved {
-  from = auth0_client.account_management_system
-  to   = auth0_client.identity_web_app
-}
+# Identity web app
+# Lets the identity web app initialise and process OAuth 2.0 / OIDC login requests through Auth0
 
 resource "auth0_client" "identity_web_app" {
   name        = "Identity web app${local.environment_qualifier}"
@@ -226,11 +221,6 @@ resource "auth0_client" "identity_web_app" {
       custom_login_page
     ]
   }
-}
-
-moved {
-  from = auth0_client_grant.account_management_system
-  to   = auth0_client_grant.identity_web_app
 }
 
 resource "auth0_client_grant" "identity_web_app" {

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -228,7 +228,12 @@ resource "auth0_client" "identity_web_app" {
   }
 }
 
-resource "auth0_client_grant" "account_management_system" {
+moved {
+  from = auth0_client_grant.account_management_system
+  to   = auth0_client_grant.identity_web_app
+}
+
+resource "auth0_client_grant" "identity_web_app" {
   client_id = auth0_client.identity_web_app.client_id
   audience  = auth0_resource_server.identity_api.identifier
 

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -185,7 +185,7 @@ resource "auth0_client" "identity_web_app" {
   is_first_party       = true
   custom_login_page_on = true
   oidc_conformant      = true
-  initiate_login_uri   = local.ams_login_uri
+  initiate_login_uri   = local.front_end_login_uri
 
   jwt_configuration {
     alg = "RS256"
@@ -212,13 +212,13 @@ resource "auth0_client" "identity_web_app" {
   ]
 
   callbacks = [
-    local.ams_redirect_uri
+    local.front_end_redirect_uri
   ]
 
   allowed_logout_urls = [
     local.wellcome_collection_site_uri,
     "${local.wellcome_collection_site_uri}/account/success",
-    local.ams_delete_requested_uri
+    local.front_end_delete_requested_uri
   ]
 
   lifecycle {

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -42,7 +42,7 @@ resource "auth0_client_grant" "deletion_tracker" {
   client_id = auth0_client.deletion_tracker.id
 
   # Management API
-  audience = "https://${aws_ssm_parameter.auth0_domain.value}/api/v2/"
+  audience = "https://${local.auth0_domain}/api/v2/"
   scope = [
     "delete:users"
   ]
@@ -69,7 +69,7 @@ resource "auth0_client" "api_gateway_identity" {
 
 resource "auth0_client_grant" "api_gateway_identity" {
   client_id = auth0_client.api_gateway_identity.id
-  audience  = "https://${aws_ssm_parameter.auth0_domain.value}/api/v2/"
+  audience  = "https://${local.auth0_domain}/api/v2/"
   scope = [
     "read:users",
     "update:users",
@@ -92,7 +92,7 @@ resource "auth0_client" "buildkite" {
 
 resource "auth0_client_grant" "buildkite" {
   client_id = auth0_client.buildkite.id
-  audience  = "https://${aws_ssm_parameter.auth0_domain.value}/api/v2/"
+  audience  = "https://${local.auth0_domain}/api/v2/"
   scope = [ # https://github.com/auth0/auth0-deploy-cli#pre-requisites
     "read:client_grants",
     "create:client_grants",

--- a/infra/scoped/auth0-connection.tf
+++ b/infra/scoped/auth0-connection.tf
@@ -60,8 +60,8 @@ resource "auth0_connection" "sierra" {
     }
 
     configuration = {
-      API_ROOT      = aws_ssm_parameter.sierra_api_hostname.value,
-      CLIENT_KEY    = local.sierra_api_credentials.client_key,
+      API_ROOT      = local.sierra_api_hostname
+      CLIENT_KEY    = local.sierra_api_credentials.client_key
       CLIENT_SECRET = local.sierra_api_credentials.client_secret
     }
   }

--- a/infra/scoped/auth0-connection.tf
+++ b/infra/scoped/auth0-connection.tf
@@ -4,7 +4,7 @@ resource "auth0_connection" "sierra" {
 
   enabled_clients = concat([
     auth0_client.api_gateway_identity.id, # Required to allow the Lambda API client credentials to operate on the connection
-    auth0_client.account_management_system.id,
+    auth0_client.identity_web_app.id,
     auth0_client.openathens_saml_idp.id,
     auth0_client.smoke_test.id],
     terraform.workspace == "stage" ? local.stage_test_client_ids : [],
@@ -40,7 +40,7 @@ resource "auth0_connection" "sierra" {
 
     password_dictionary {
       enable     = true
-      dictionary = ["wellcome"]
+      dictionary = ["wellcome", "Wellcome"]
     }
 
     password_complexity_options {

--- a/infra/scoped/auth0-logs.tf
+++ b/infra/scoped/auth0-logs.tf
@@ -11,7 +11,7 @@ resource "auth0_log_stream" "eventbridge" {
 
 locals {
   auth0_logs_event_source = auth0_log_stream.eventbridge.sink[0].aws_partner_event_source
-  tenant_name             = split(".", aws_ssm_parameter.auth0_domain.value)[0]
+  tenant_name             = split(".", local.auth0_domain)[0]
 }
 
 resource "aws_cloudwatch_event_bus" "auth0_logs" {

--- a/infra/scoped/auth0-tenant.tf
+++ b/infra/scoped/auth0-tenant.tf
@@ -1,8 +1,8 @@
 resource "auth0_tenant" "tenant" {
-  friendly_name = "${aws_ssm_parameter.auth0_friendly_name.value}${local.environment_qualifier}"
+  friendly_name = "${local.auth0_friendly_name}${local.environment_qualifier}"
   picture_url   = "https://${aws_s3_bucket.assets.bucket_regional_domain_name}/${aws_s3_bucket_object.assets_images_wellcomecollections-150x50-png.key}"
   support_email = local.email_support_address
-  support_url   = aws_ssm_parameter.auth0_support_url.value
+  support_url   = local.auth0_support_url
 
   # This is required for the 'password' grant type that is used when testing user credentials
   default_directory = auth0_connection.sierra.name
@@ -17,8 +17,8 @@ resource "auth0_tenant" "tenant" {
 
   universal_login {
     colors {
-      primary         = aws_ssm_parameter.auth0_universal_login_primary_colour.value
-      page_background = aws_ssm_parameter.auth0_universal_login_background_colour.value
+      primary         = local.auth0_universal_login_primary_colour
+      page_background = local.auth0_universal_login_background_colour
     }
   }
 

--- a/infra/scoped/auth0-tenant.tf
+++ b/infra/scoped/auth0-tenant.tf
@@ -42,6 +42,6 @@ resource "auth0_tenant" "tenant" {
   error_page {
     html          = "unset"
     show_log_link = false
-    url           = local.ams_error_uri
+    url           = local.front_end_error_uri
   }
 }

--- a/infra/scoped/lambda.tf
+++ b/infra/scoped/lambda.tf
@@ -101,9 +101,9 @@ resource "aws_lambda_function" "api" {
       EMAIL_SMTP_PASSWORD  = local.email_credentials["smtp_password"],
       EMAIL_FROM_ADDRESS   = local.email_noreply_name_and_address,
       EMAIL_ADMIN_ADDRESS  = aws_ssm_parameter.email_admin_address.value,
-      SUPPORT_URL          = aws_ssm_parameter.auth0_support_url.value,
-      SIERRA_API_ROOT      = aws_ssm_parameter.sierra_api_hostname.value,
-      SIERRA_CLIENT_KEY    = local.sierra_api_credentials.client_key,
+      SUPPORT_URL          = local.auth0_support_url
+      SIERRA_API_ROOT      = local.sierra_api_hostname
+      SIERRA_CLIENT_KEY    = local.sierra_api_credentials.client_key
       SIERRA_CLIENT_SECRET = local.sierra_api_credentials.client_secret
     }
   }
@@ -168,11 +168,11 @@ resource "aws_lambda_function" "patron_deletion_tracker" {
   environment {
     variables = {
       AUTH0_API_ROOT       = local.auth0_endpoint
-      AUTH0_API_AUDIENCE   = auth0_client_grant.deletion_tracker.audience,
-      AUTH0_CLIENT_ID      = auth0_client.deletion_tracker.client_id,
-      AUTH0_CLIENT_SECRET  = auth0_client.deletion_tracker.client_secret,
-      SIERRA_API_ROOT      = aws_ssm_parameter.sierra_api_hostname.value,
-      SIERRA_CLIENT_KEY    = local.sierra_api_credentials.client_key,
+      AUTH0_API_AUDIENCE   = auth0_client_grant.deletion_tracker.audience
+      AUTH0_CLIENT_ID      = auth0_client.deletion_tracker.client_id
+      AUTH0_CLIENT_SECRET  = auth0_client.deletion_tracker.client_secret
+      SIERRA_API_ROOT      = local.sierra_api_hostname
+      SIERRA_CLIENT_KEY    = local.sierra_api_credentials.client_key
       SIERRA_CLIENT_SECRET = local.sierra_api_credentials.client_secret
     }
   }

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -62,14 +62,14 @@ locals {
   }
   catalogue_api_public_root = "https://${local.catalogue_api_hostnames[terraform.workspace]}/catalogue/v2"
 
-  # Account Management System
-  ams_context_path         = "account"
-  ams_redirect_uri         = "${local.wellcome_collection_site_uri}/${local.ams_context_path}/api/auth/callback"
-  ams_login_uri            = "${local.wellcome_collection_site_uri}/${local.ams_context_path}/api/auth/login"
-  ams_error_uri            = "${local.wellcome_collection_site_uri}/${local.ams_context_path}/error"
-  ams_validate_uri         = "${local.wellcome_collection_site_uri}/${local.ams_context_path}/validated"
-  ams_delete_requested_uri = "${local.wellcome_collection_site_uri}/${local.ams_context_path}/delete-requested"
-  ams_registration_uri     = "${local.wellcome_collection_site_uri}/${local.ams_context_path}/registration"
+  # Front-end / identity web app
+  front_end_context_path         = "account"
+  front_end_redirect_uri         = "${local.wellcome_collection_site_uri}/${local.front_end_context_path}/api/auth/callback"
+  front_end_login_uri            = "${local.wellcome_collection_site_uri}/${local.front_end_context_path}/api/auth/login"
+  front_end_error_uri            = "${local.wellcome_collection_site_uri}/${local.front_end_context_path}/error"
+  front_end_validate_uri         = "${local.wellcome_collection_site_uri}/${local.front_end_context_path}/validated"
+  front_end_delete_requested_uri = "${local.wellcome_collection_site_uri}/${local.front_end_context_path}/delete-requested"
+  front_end_registration_uri     = "${local.wellcome_collection_site_uri}/${local.front_end_context_path}/registration"
 
   # Identity account VPC
   identity_account_state = data.terraform_remote_state.accounts_identity.outputs

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -19,9 +19,9 @@ locals {
   environment_qualifier = terraform.workspace != "prod" ? " (${upper(terraform.workspace)})" : ""
 
   # Email
-  email_support_address          = "${aws_ssm_parameter.email_support_user.value}@${data.aws_ssm_parameter.email_domain.value}"
-  email_noreply_address          = "${aws_ssm_parameter.email_noreply_user.value}@${data.aws_ssm_parameter.email_domain.value}"
-  email_noreply_name_and_address = "${aws_ssm_parameter.email_noreply_name.value} <${local.email_noreply_address}>"
+  email_support_address          = "${local.email_support_user}@${data.aws_ssm_parameter.email_domain.value}"
+  email_noreply_address          = "${local.email_noreply_user}@${data.aws_ssm_parameter.email_domain.value}"
+  email_noreply_name_and_address = "${local.email_noreply_name} <${local.email_noreply_address}>"
 
   # Credentials exported from static stack in the format:
   # {
@@ -32,8 +32,10 @@ locals {
   # }
   email_credentials = jsondecode(data.aws_secretsmanager_secret_version.email_credentials_secret_version.secret_string)
 
+  hostname_prefix = trimspace(aws_ssm_parameter.external_parameters["hostname_prefix"].value)
+
   # API Gateway
-  api_hostname = nonsensitive("api.${trimspace(aws_ssm_parameter.hostname_prefix.value)}${data.aws_ssm_parameter.hostname.value}")
+  api_hostname = nonsensitive("api.${local.hostname_prefix}${data.aws_ssm_parameter.hostname.value}")
 
   # API Gateway V1
   identity_v1               = "v1"
@@ -43,7 +45,7 @@ locals {
   identity_v1_docs_endpoint = "https://${local.identity_v1_docs_hostname}"
 
   # Auth0
-  auth0_hostname = nonsensitive("${trimspace(aws_ssm_parameter.hostname_prefix.value)}${data.aws_ssm_parameter.hostname.value}")
+  auth0_hostname = nonsensitive("${local.hostname_prefix}${data.aws_ssm_parameter.hostname.value}")
   auth0_endpoint = "https://${local.auth0_hostname}"
 
   # Wellcome Collection Site

--- a/infra/scoped/output.tf
+++ b/infra/scoped/output.tf
@@ -43,7 +43,7 @@ output "auth0_openathens_saml_idp_client_id" {
 
 output "ci_environment_variables" {
   value = [
-    "export AUTH0_DOMAIN=${aws_ssm_parameter.auth0_domain.value}",
+    "export AUTH0_DOMAIN=${local.auth0_domain}",
     "export AUTH0_CLIENT_ID=${auth0_client.buildkite.client_id}",
     "export AUTH0_CLIENT_SECRET=${auth0_client.buildkite.client_secret}",
     "export AUTH0_CONNECTION_NAME=${auth0_connection.sierra.name}",

--- a/infra/scoped/parameters.tf
+++ b/infra/scoped/parameters.tf
@@ -260,72 +260,61 @@ resource "aws_ssm_parameter" "cloudwatch_retention" {
   }
 }
 
-# Account Management System
+# Account Management System / identity web app
 
-resource "aws_ssm_parameter" "account_management_system-auth0_domain" {
-  provider = aws.experience
-  name     = "/identity/${terraform.workspace}/account_management_system/auth0_domain"
-  type     = "String"
-  value    = local.auth0_hostname
-
-  tags = {
-    "Name" = "/identity/${terraform.workspace}/account_management_system/auth0_domain"
+locals {
+  ssm_parameters = {
+    auth0_domain        = local.auth0_hostname
+    auth0_client_id     = auth0_client.identity_web_app.id
+    auth0_callback_url  = local.ams_redirect_uri
+    api_base_url        = local.identity_v1_endpoint
+    context_path        = local.ams_context_path
+    logout_redirect_url = local.wellcome_collection_site_uri
   }
 }
 
-resource "aws_ssm_parameter" "account_management_system-auth0_client_id" {
-  provider = aws.experience
-  name     = "/identity/${terraform.workspace}/account_management_system/auth0_client_id"
-  type     = "String"
-  value    = auth0_client.identity_web_app.id
-
-  tags = {
-    "Name" = "/identity/${terraform.workspace}/account_management_system/auth0_client_id"
-  }
+moved {
+  from = aws_ssm_parameter.account_management_system-auth0_domain
+  to   = aws_ssm_parameter.account_management_system["auth0_domain"]
 }
 
-resource "aws_ssm_parameter" "account_management_system-auth0_callback_url" {
-  provider = aws.experience
-  name     = "/identity/${terraform.workspace}/account_management_system/auth0_callback_url"
-  type     = "String"
-  value    = local.ams_redirect_uri
-
-  tags = {
-    "Name" = "/identity/${terraform.workspace}/account_management_system/auth0_callback_url"
-  }
+moved {
+  from = aws_ssm_parameter.account_management_system-auth0_client_id
+  to   = aws_ssm_parameter.account_management_system["auth0_client_id"]
 }
 
-resource "aws_ssm_parameter" "account_management_system-api_base_url" {
-  provider = aws.experience
-  name     = "/identity/${terraform.workspace}/account_management_system/api_base_url"
-  type     = "String"
-  value    = local.identity_v1_endpoint
-
-  tags = {
-    "Name" = "/identity/${terraform.workspace}/account_management_system/api_base_url"
-  }
+moved {
+  from = aws_ssm_parameter.account_management_system-auth0_callback_url
+  to   = aws_ssm_parameter.account_management_system["auth0_callback_url"]
 }
 
-resource "aws_ssm_parameter" "account_management_system-context_path" {
-  provider = aws.experience
-  name     = "/identity/${terraform.workspace}/account_management_system/context_path"
-  type     = "String"
-  value    = local.ams_context_path
-
-  tags = {
-    "Name" = "/identity/${terraform.workspace}/account_management_system/context_path"
-  }
+moved {
+  from = aws_ssm_parameter.account_management_system-api_base_url
+  to   = aws_ssm_parameter.account_management_system["api_base_url"]
 }
 
-resource "aws_ssm_parameter" "account_management_system-logout_redirect_url" {
-  provider = aws.experience
-  name     = "/identity/${terraform.workspace}/account_management_system/logout_redirect_url"
-  type     = "String"
-  value    = local.wellcome_collection_site_uri
+moved {
+  from = aws_ssm_parameter.account_management_system-context_path
+  to   = aws_ssm_parameter.account_management_system["context_path"]
+}
+
+moved {
+  from = aws_ssm_parameter.account_management_system-logout_redirect_url
+  to   = aws_ssm_parameter.account_management_system["logout_redirect_url"]
+}
+
+resource "aws_ssm_parameter" "account_management_system" {
+  for_each = local.ssm_parameters
+
+  name  = "/identity/${terraform.workspace}/account_management_system/${each.key}"
+  value = each.value
+  type  = "String"
 
   tags = {
-    "Name" = "/identity/${terraform.workspace}/account_management_system/logout_redirect_url"
+    "Name" = "/identity/${terraform.workspace}/account_management_system/${each.key}"
   }
+
+  provider = aws.experience
 }
 
 # Email

--- a/infra/scoped/parameters.tf
+++ b/infra/scoped/parameters.tf
@@ -4,238 +4,148 @@ data "aws_ssm_parameter" "hostname" {
   name = "identity-hostname"
 }
 
-resource "aws_ssm_parameter" "hostname_prefix" {
-  name  = "identity-hostname_prefix-${terraform.workspace}"
-  type  = "String"
+locals {
+  external_ssm_parameters = [
+    "hostname_prefix",
+
+    # Email
+    "email_support_user",
+    "email_noreply_user",
+    "email_noreply_name",
+
+    # Sierra
+    "sierra_api_hostname",
+
+    # Auth0
+    "auth0_friendly_name",
+    "auth0_universal_login_primary_colour",
+    "auth0_universal_login_background_colour",
+    "auth0_domain",
+    "auth0_support_url",
+    "auth0_verify_email_subject",
+    "auth0_verify_email_url_ttl",
+    "auth0_reset_email_subject",
+    "auth0_reset_email_url_ttl",
+    "auth0_welcome_email_subject",
+    "auth0_blocked_email_subject",
+  ]
+}
+
+moved {
+  from = aws_ssm_parameter.hostname_prefix
+  to   = aws_ssm_parameter.external_parameters["hostname_prefix"]
+}
+
+moved {
+  from = aws_ssm_parameter.email_support_user
+  to   = aws_ssm_parameter.external_parameters["email_support_user"]
+}
+
+moved {
+  from = aws_ssm_parameter.email_noreply_user
+  to   = aws_ssm_parameter.external_parameters["email_noreply_user"]
+}
+
+moved {
+  from = aws_ssm_parameter.email_noreply_name
+  to   = aws_ssm_parameter.external_parameters["email_noreply_name"]
+}
+
+moved {
+  from = aws_ssm_parameter.sierra_api_hostname
+  to   = aws_ssm_parameter.external_parameters["sierra_api_hostname"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_friendly_name
+  to   = aws_ssm_parameter.external_parameters["auth0_friendly_name"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_universal_login_primary_colour
+  to   = aws_ssm_parameter.external_parameters["auth0_universal_login_primary_colour"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_universal_login_background_colour
+  to   = aws_ssm_parameter.external_parameters["auth0_universal_login_background_colour"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_domain
+  to   = aws_ssm_parameter.external_parameters["auth0_domain"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_support_url
+  to   = aws_ssm_parameter.external_parameters["auth0_support_url"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_verify_email_subject
+  to   = aws_ssm_parameter.external_parameters["auth0_verify_email_subject"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_verify_email_url_ttl
+  to   = aws_ssm_parameter.external_parameters["auth0_verify_email_url_ttl"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_reset_email_subject
+  to   = aws_ssm_parameter.external_parameters["auth0_reset_email_subject"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_reset_email_url_ttl
+  to   = aws_ssm_parameter.external_parameters["auth0_reset_email_url_ttl"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_welcome_email_subject
+  to   = aws_ssm_parameter.external_parameters["auth0_welcome_email_subject"]
+}
+
+moved {
+  from = aws_ssm_parameter.auth0_blocked_email_subject
+  to   = aws_ssm_parameter.external_parameters["auth0_blocked_email_subject"]
+}
+
+resource "aws_ssm_parameter" "external_parameters" {
+  for_each = toset(local.external_ssm_parameters)
+
+  name  = "identity-${each.key}-${terraform.workspace}"
   value = var.ssm_parameter_placeholder_string
+  type  = "String"
 
   lifecycle {
     ignore_changes = [value]
   }
 
   tags = {
-    "Name" = "identity-hostname_prefix-${terraform.workspace}"
+    "Name" = "identity-${each.key}-${terraform.workspace}"
   }
+}
+
+locals {
+  auth0_domain        = aws_ssm_parameter.external_parameters["auth0_domain"].value
+  auth0_support_url   = aws_ssm_parameter.external_parameters["auth0_support_url"].value
+  auth0_friendly_name = aws_ssm_parameter.external_parameters["auth0_friendly_name"].value
+
+  auth0_universal_login_primary_colour    = aws_ssm_parameter.external_parameters["auth0_universal_login_primary_colour"].value
+  auth0_universal_login_background_colour = aws_ssm_parameter.external_parameters["auth0_universal_login_background_colour"].value
+
+  sierra_api_hostname = aws_ssm_parameter.external_parameters["sierra_api_hostname"].value
+
+  email_support_user = aws_ssm_parameter.external_parameters["email_support_user"].value
+  email_noreply_user = aws_ssm_parameter.external_parameters["email_noreply_user"].value
+  email_noreply_name = aws_ssm_parameter.external_parameters["email_noreply_name"].value
 }
 
 # Email
 
-resource "aws_ssm_parameter" "email_support_user" {
-  name  = "identity-email_support_user-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-email_support_user-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "email_noreply_user" {
-  name  = "identity-email_noreply_user-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-email_noreply_user-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "email_noreply_name" {
-  name  = "identity-email_noreply_name-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-email_noreply_name-${terraform.workspace}"
-  }
-}
-
 data "aws_ssm_parameter" "email_domain" {
   name = "identity-email_domain"
-}
-
-# Sierra
-
-resource "aws_ssm_parameter" "sierra_api_hostname" {
-  name  = "identity-sierra_api_hostname-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-sierra_api_hostname-${terraform.workspace}"
-  }
-}
-
-# Auth0
-
-resource "aws_ssm_parameter" "auth0_friendly_name" {
-  name  = "identity-auth0_friendly_name-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_friendly_name-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_universal_login_primary_colour" {
-  name  = "identity-auth0_universal_login_primary_colour-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_universal_login_primary_colour-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_universal_login_background_colour" {
-  name  = "identity-auth0_universal_login_background_colour-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_universal_login_background_colour-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_domain" {
-  name  = "identity-auth0_domain-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_domain-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_support_url" {
-  name  = "identity-auth0_support_url-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_support_url-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_verify_email_subject" {
-  name  = "identity-auth0_verify_email_subject-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_verify_email_subject-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_verify_email_url_ttl" {
-  name  = "identity-auth0_verify_email_url_ttl-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_number
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_verify_email_url_ttl-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_reset_email_subject" {
-  name  = "identity-auth0_reset_email_subject-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_reset_email_subject-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_reset_email_url_ttl" {
-  name  = "identity-auth0_reset_email_url_ttl-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_number
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_reset_email_url_ttl-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_welcome_email_subject" {
-  name  = "identity-auth0_welcome_email_subject-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_welcome_email_subject-${terraform.workspace}"
-  }
-}
-
-resource "aws_ssm_parameter" "auth0_blocked_email_subject" {
-  name  = "identity-auth0_blocked_email_subject-${terraform.workspace}"
-  type  = "String"
-  value = var.ssm_parameter_placeholder_string
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-
-  tags = {
-    "Name" = "identity-auth0_blocked_email_subject-${terraform.workspace}"
-  }
 }
 
 # API Gateway

--- a/infra/scoped/parameters.tf
+++ b/infra/scoped/parameters.tf
@@ -31,86 +31,6 @@ locals {
   ]
 }
 
-moved {
-  from = aws_ssm_parameter.hostname_prefix
-  to   = aws_ssm_parameter.external_parameters["hostname_prefix"]
-}
-
-moved {
-  from = aws_ssm_parameter.email_support_user
-  to   = aws_ssm_parameter.external_parameters["email_support_user"]
-}
-
-moved {
-  from = aws_ssm_parameter.email_noreply_user
-  to   = aws_ssm_parameter.external_parameters["email_noreply_user"]
-}
-
-moved {
-  from = aws_ssm_parameter.email_noreply_name
-  to   = aws_ssm_parameter.external_parameters["email_noreply_name"]
-}
-
-moved {
-  from = aws_ssm_parameter.sierra_api_hostname
-  to   = aws_ssm_parameter.external_parameters["sierra_api_hostname"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_friendly_name
-  to   = aws_ssm_parameter.external_parameters["auth0_friendly_name"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_universal_login_primary_colour
-  to   = aws_ssm_parameter.external_parameters["auth0_universal_login_primary_colour"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_universal_login_background_colour
-  to   = aws_ssm_parameter.external_parameters["auth0_universal_login_background_colour"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_domain
-  to   = aws_ssm_parameter.external_parameters["auth0_domain"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_support_url
-  to   = aws_ssm_parameter.external_parameters["auth0_support_url"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_verify_email_subject
-  to   = aws_ssm_parameter.external_parameters["auth0_verify_email_subject"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_verify_email_url_ttl
-  to   = aws_ssm_parameter.external_parameters["auth0_verify_email_url_ttl"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_reset_email_subject
-  to   = aws_ssm_parameter.external_parameters["auth0_reset_email_subject"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_reset_email_url_ttl
-  to   = aws_ssm_parameter.external_parameters["auth0_reset_email_url_ttl"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_welcome_email_subject
-  to   = aws_ssm_parameter.external_parameters["auth0_welcome_email_subject"]
-}
-
-moved {
-  from = aws_ssm_parameter.auth0_blocked_email_subject
-  to   = aws_ssm_parameter.external_parameters["auth0_blocked_email_subject"]
-}
-
 resource "aws_ssm_parameter" "external_parameters" {
   for_each = toset(local.external_ssm_parameters)
 
@@ -181,36 +101,6 @@ locals {
     context_path        = local.front_end_context_path
     logout_redirect_url = local.wellcome_collection_site_uri
   }
-}
-
-moved {
-  from = aws_ssm_parameter.account_management_system-auth0_domain
-  to   = aws_ssm_parameter.account_management_system["auth0_domain"]
-}
-
-moved {
-  from = aws_ssm_parameter.account_management_system-auth0_client_id
-  to   = aws_ssm_parameter.account_management_system["auth0_client_id"]
-}
-
-moved {
-  from = aws_ssm_parameter.account_management_system-auth0_callback_url
-  to   = aws_ssm_parameter.account_management_system["auth0_callback_url"]
-}
-
-moved {
-  from = aws_ssm_parameter.account_management_system-api_base_url
-  to   = aws_ssm_parameter.account_management_system["api_base_url"]
-}
-
-moved {
-  from = aws_ssm_parameter.account_management_system-context_path
-  to   = aws_ssm_parameter.account_management_system["context_path"]
-}
-
-moved {
-  from = aws_ssm_parameter.account_management_system-logout_redirect_url
-  to   = aws_ssm_parameter.account_management_system["logout_redirect_url"]
 }
 
 resource "aws_ssm_parameter" "account_management_system" {

--- a/infra/scoped/parameters.tf
+++ b/infra/scoped/parameters.tf
@@ -176,9 +176,9 @@ locals {
   ssm_parameters = {
     auth0_domain        = local.auth0_hostname
     auth0_client_id     = auth0_client.identity_web_app.id
-    auth0_callback_url  = local.ams_redirect_uri
+    auth0_callback_url  = local.front_end_redirect_uri
     api_base_url        = local.identity_v1_endpoint
-    context_path        = local.ams_context_path
+    context_path        = local.front_end_context_path
     logout_redirect_url = local.wellcome_collection_site_uri
   }
 }

--- a/infra/scoped/parameters.tf
+++ b/infra/scoped/parameters.tf
@@ -277,7 +277,7 @@ resource "aws_ssm_parameter" "account_management_system-auth0_client_id" {
   provider = aws.experience
   name     = "/identity/${terraform.workspace}/account_management_system/auth0_client_id"
   type     = "String"
-  value    = auth0_client.account_management_system.id
+  value    = auth0_client.identity_web_app.id
 
   tags = {
     "Name" = "/identity/${terraform.workspace}/account_management_system/auth0_client_id"

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -85,7 +85,7 @@ module "secrets_experience" {
   source = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.3.0"
 
   key_value_map = {
-    "identity/${terraform.workspace}/account_management_system/auth0_client_secret" = auth0_client.account_management_system.client_secret
+    "identity/${terraform.workspace}/account_management_system/auth0_client_secret" = auth0_client.identity_web_app.client_secret
     "identity/${terraform.workspace}/account_management_system/api_key"             = aws_api_gateway_api_key.account_management_system.value
     "identity/${terraform.workspace}/redirect_action_secret"                        = data.aws_secretsmanager_secret_version.redirect_action_secret.secret_string
   }

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -74,7 +74,7 @@ module "secrets" {
   source = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.3.0"
 
   key_value_map = {
-    "identity/${terraform.workspace}/account_management_system/api_key" = aws_api_gateway_api_key.account_management_system.value
+    "identity/${terraform.workspace}/account_management_system/api_key" = aws_api_gateway_api_key.identity_web_app.value
     "identity/${terraform.workspace}/buildkite/credentials"             = jsonencode(local.buildkite_credentials)
     "identity/${terraform.workspace}/smoke_test/credentials"            = jsonencode(local.smoke_test_credentials)
   }
@@ -86,7 +86,7 @@ module "secrets_experience" {
 
   key_value_map = {
     "identity/${terraform.workspace}/account_management_system/auth0_client_secret" = auth0_client.identity_web_app.client_secret
-    "identity/${terraform.workspace}/account_management_system/api_key"             = aws_api_gateway_api_key.account_management_system.value
+    "identity/${terraform.workspace}/account_management_system/api_key"             = aws_api_gateway_api_key.identity_web_app.value
     "identity/${terraform.workspace}/redirect_action_secret"                        = data.aws_secretsmanager_secret_version.redirect_action_secret.secret_string
   }
 


### PR DESCRIPTION
There is no service called "Account Management System"; there's the identity web app in the dotorg repo. This name is a leftover Digirati-ism.

It'll be a bit of a faff to remove it completely, but we can start moving in that direction for resources that support easy renaming (including applications in Auth0 and API Gateway API keys).

I was actually trying to create a documented, turnkey process for devs to create clients that they could use when running the identity web app locally, but I got distracted by bad naming.

~This is currently applied in staging only; if we like it I'll apply it in prod then delete all the `moved` blocks.~ I had to apply in prod to deploy the "resend email verification" stuff, and this seemed harmless enough.