### PR TITLE
Define permissions for identity CI in this repo

### DIFF
--- a/infra/scoped/iam-ci.tf
+++ b/infra/scoped/iam-ci.tf
@@ -1,0 +1,30 @@
+locals {
+  identity_ci_role_name = element(
+    split("/", local.identity_account_state.ci_role_arn),
+    length(split("/", local.identity_account_state.ci_role_arn)) - 1
+  )
+}
+
+resource "aws_iam_role_policy" "identity_ci" {
+  name   = "smoke-tests-${terraform.workspace}"
+  role   = local.identity_ci_role_name
+  policy = data.aws_iam_policy_document.identity_ci.json
+}
+
+data "aws_iam_policy_document" "identity_ci" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = module.secrets.arns
+  }
+
+  statement {
+    actions = [
+      "ssm:GetParameter",
+    ]
+
+    resources = [aws_ssm_parameter.identity_web_app["auth0_domain"].arn]
+  }
+}


### PR DESCRIPTION
For https://github.com/wellcomecollection/identity/issues/372. Accompanies https://github.com/wellcomecollection/platform-infrastructure/pull/321. This should fix the broken deployments.