### PR TITLE
Export creds for a local dev client to Secrets Manager

### DIFF
--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -8,8 +8,7 @@ locals {
     TerraformConfigurationURL = "https://github.com/wellcomecollection/identity/tree/main/infra/scoped"
   }
 
-  stage_test_client_ids = compact([
-    length(auth0_client.dummy_test) > 0 ? auth0_client.dummy_test[0].client_id : "",
+  stage_test_client_ids = concat(auth0_client.local_dev_client.*.client_id, [
     # Developer client ids can be added here
     "SrigIHZ3yXKlskZcdxJeytBuHqUUw7gn", // "David McCormick – Local Dev"
     "NOx1lzM8ivV0ec0H3BMoxKGqXwJJF1em", // "Jamie Parkinson - Local Dev"

--- a/infra/scoped/output.tf
+++ b/infra/scoped/output.tf
@@ -17,24 +17,6 @@ output "auth0_endpoint" {
 
 # Auth0 clients
 
-output "auth0_client_dummy_name" {
-  value = auth0_client.dummy_test.*.name
-}
-
-output "auth0_client_dummy_api_key" {
-  value     = aws_api_gateway_api_key.dummy.*.value
-  sensitive = true
-}
-
-output "auth0_client_dummy_client_id" {
-  value = auth0_client.dummy_test.*.client_id
-}
-
-output "auth0_client_dummy_client_secret" {
-  value     = auth0_client.dummy_test.*.client_secret
-  sensitive = true
-}
-
 output "auth0_openathens_saml_idp_client_id" {
   value = auth0_client.openathens_saml_idp.client_id
 }

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -67,17 +67,28 @@ locals {
     clientId : auth0_client.buildkite.id
     clientSecret : auth0_client.buildkite.client_secret
   }
+
+  local_dev_client_credentials = lower(terraform.workspace) != "prod" ? {
+    client_name   = auth0_client.dummy_test[0].name
+    api_key       = aws_api_gateway_api_key.dummy[0].value
+    client_id     = auth0_client.dummy_test[0].client_id
+    client_secret = auth0_client.dummy_test[0].client_secret
+  } : {}
 }
 
 # Secrets that we set in the identity account
 module "secrets" {
   source = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.3.0"
 
-  key_value_map = {
-    "identity/${terraform.workspace}/identity_web_app/api_key" = aws_api_gateway_api_key.identity_web_app.value
-    "identity/${terraform.workspace}/buildkite/credentials"    = jsonencode(local.buildkite_credentials)
-    "identity/${terraform.workspace}/smoke_test/credentials"   = jsonencode(local.smoke_test_credentials)
-  }
+  key_value_map = merge({
+    "identity/${terraform.workspace}/identity_web_app/api_key"     = aws_api_gateway_api_key.identity_web_app.value
+    "identity/${terraform.workspace}/buildkite/credentials"        = jsonencode(local.buildkite_credentials)
+    "identity/${terraform.workspace}/smoke_test/credentials"       = jsonencode(local.smoke_test_credentials)
+  },
+    lower(terraform.workspace) != "prod" ? {
+      "identity/${terraform.workspace}/local_dev_client/credentials" = jsonencode(local.local_dev_client_credentials)
+    } : {}
+  )
 }
 
 # Secrets that need to be exported to the experience account

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -81,10 +81,10 @@ module "secrets" {
   source = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.3.0"
 
   key_value_map = merge({
-    "identity/${terraform.workspace}/identity_web_app/api_key"     = aws_api_gateway_api_key.identity_web_app.value
-    "identity/${terraform.workspace}/buildkite/credentials"        = jsonencode(local.buildkite_credentials)
-    "identity/${terraform.workspace}/smoke_test/credentials"       = jsonencode(local.smoke_test_credentials)
-  },
+    "identity/${terraform.workspace}/identity_web_app/api_key" = aws_api_gateway_api_key.identity_web_app.value
+    "identity/${terraform.workspace}/buildkite/credentials"    = jsonencode(local.buildkite_credentials)
+    "identity/${terraform.workspace}/smoke_test/credentials"   = jsonencode(local.smoke_test_credentials)
+    },
     lower(terraform.workspace) != "prod" ? {
       "identity/${terraform.workspace}/local_dev_client/credentials" = jsonencode(local.local_dev_client_credentials)
     } : {}

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -69,10 +69,10 @@ locals {
   }
 
   local_dev_client_credentials = lower(terraform.workspace) != "prod" ? {
-    client_name   = auth0_client.dummy_test[0].name
+    client_name   = auth0_client.local_dev_client[0].name
     api_key       = aws_api_gateway_api_key.dummy[0].value
-    client_id     = auth0_client.dummy_test[0].client_id
-    client_secret = auth0_client.dummy_test[0].client_secret
+    client_id     = auth0_client.local_dev_client[0].client_id
+    client_secret = auth0_client.local_dev_client[0].client_secret
   } : {}
 }
 


### PR DESCRIPTION
These can then be retrieved programatically to start a local copy of the identity web app.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/8288