### PR TITLE
Don't show an "Enroll in multi-factor authentication" message to users

### DIFF
--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -247,19 +247,16 @@
         }
       }
     </style>
-
-    {% if prompt.screen.texts.pageTitle == "Enroll in multi-factor authentication" %}
-      {% comment %}
-        This branch is working around a strange behaviour where
-        Auth0 shows the MFA enrollment message even though we don’t
-        allow users to configure MFA.  We don’t want to confuse them,
-        so we show them a different message.
-
-        See https://github.com/wellcomecollection/wellcomecollection.org/issues/8289
-      {% endcomment %}
-      <title>Please wait a few seconds while we complete your verification</title>
+    {% if prompt.screen.texts.pageTitle == "Enroll in multi-factor
+    authentication" %} {% comment %} This branch is working around a strange
+    behaviour where Auth0 shows the MFA enrollment message even though we don’t
+    allow users to configure MFA. We don’t want to confuse them, so we show them
+    a different message. See
+    https://github.com/wellcomecollection/wellcomecollection.org/issues/8289 {%
+    endcomment %}
+    <title>Please wait a few seconds while we complete your verification</title>
     {% else %}
-      <title>{{ prompt.screen.texts.pageTitle }}</title>
+    <title>{{ prompt.screen.texts.pageTitle }}</title>
     {% endif %}
   </head>
 
@@ -289,24 +286,22 @@
     <div class="container">
       <div class="container-inner">
         <!-- Here we need to show the description message -->
-        {% if prompt.screen.texts.pageTitle == "Enroll in multi-factor authentication" %}
-          {% comment %}
-            This branch is working around a strange behaviour where
-            Auth0 shows the MFA enrollment message even though we don’t
-            allow users to configure MFA.  We don’t want to confuse them,
-            so we show them a different message.
-
-            See https://github.com/wellcomecollection/wellcomecollection.org/issues/8289
-          {% endcomment %}
-          <h1>Please wait a few seconds while we complete your verification</h1>
-          <p>
-            If you aren&rsquo;t redirected within ten seconds, please
-            <a href="mailto:library@wellcomecollection.org"
-              >contact the library team</a
-            >.
-          </p>
+        {% if prompt.screen.texts.pageTitle == "Enroll in multi-factor
+        authentication" %} {% comment %} This branch is working around a strange
+        behaviour where Auth0 shows the MFA enrollment message even though we
+        don’t allow users to configure MFA. We don’t want to confuse them, so we
+        show them a different message. See
+        https://github.com/wellcomecollection/wellcomecollection.org/issues/8289
+        {% endcomment %}
+        <h1>Please wait a few seconds while we complete your verification</h1>
+        <p>
+          If you aren&rsquo;t redirected within ten seconds, please
+          <a href="mailto:library@wellcomecollection.org"
+            >contact the library team</a
+          >.
+        </p>
         {% else %}
-          <h1>{{ prompt.screen.texts.pageTitle }}</h1>
+        <h1>{{ prompt.screen.texts.pageTitle }}</h1>
         {% endif %}
 
         <!-- Text that appears before the login/sign-up form fields -->

--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -302,7 +302,7 @@
           <p>
             If you aren&rsquo;t redirected within ten seconds, please
             <a href="mailto:library@wellcomecollection.org"
-              >Contact the library team</a
+              >contact the library team</a
             >.
           </p>
         {% else %}

--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -247,7 +247,20 @@
         }
       }
     </style>
-    <title>{{ prompt.screen.texts.pageTitle }}</title>
+
+    {% if prompt.screen.texts.pageTitle == "Enroll in multi-factor authentication" %}
+      {% comment %}
+        This branch is working around a strange behaviour where
+        Auth0 shows the MFA enrollment message even though we don’t
+        allow users to configure MFA.  We don’t want to confuse them,
+        so we show them a different message.
+
+        See https://github.com/wellcomecollection/wellcomecollection.org/issues/8289
+      {% endcomment %}
+      <title>Please wait a few seconds while we complete your verification</title>
+    {% else %}
+      <title>{{ prompt.screen.texts.pageTitle }}</title>
+    {% endif %}
   </head>
 
   <body class="_hide-prompt-logo">

--- a/universal_login/templates/universal-login.html
+++ b/universal_login/templates/universal-login.html
@@ -276,7 +276,25 @@
     <div class="container">
       <div class="container-inner">
         <!-- Here we need to show the description message -->
-        <h1>{{ prompt.screen.texts.pageTitle }}</h1>
+        {% if prompt.screen.texts.pageTitle == "Enroll in multi-factor authentication" %}
+          {% comment %}
+            This branch is working around a strange behaviour where
+            Auth0 shows the MFA enrollment message even though we don’t
+            allow users to configure MFA.  We don’t want to confuse them,
+            so we show them a different message.
+
+            See https://github.com/wellcomecollection/wellcomecollection.org/issues/8289
+          {% endcomment %}
+          <h1>Please wait a few seconds while we complete your verification</h1>
+          <p>
+            If you aren&rsquo;t redirected within ten seconds, please
+            <a href="mailto:library@wellcomecollection.org"
+              >Contact the library team</a
+            >.
+          </p>
+        {% else %}
+          <h1>{{ prompt.screen.texts.pageTitle }}</h1>
+        {% endif %}
 
         <!-- Text that appears before the login/sign-up form fields -->
         {% if prompt.name == "login" %}


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8289

I realised the page is being shown using our `universal-login.html` template, so I added a hard-coded workaround for this specific message. This is what the new page looks like:

<img width="980" alt="Screenshot 2022-08-22 at 07 42 10" src="https://user-images.githubusercontent.com/301220/185855838-56ab509e-e09b-47eb-9f9c-2d09fd9642cc.png">

It's obviously a bit unsatisfying to have a hacky fix, but it works and means we don't have to spend more time on this. 