### PR TITLE
Enable more specific errors for 'User already exists'

### DIFF
--- a/infra/scoped/auth0-tenant.tf
+++ b/infra/scoped/auth0-tenant.tf
@@ -13,6 +13,26 @@ resource "auth0_tenant" "tenant" {
   flags {
     enable_custom_domain_in_emails = true
     universal_login                = true # Enables the 'new' Universal Login experience
+
+    # This is the Auth0 dashboard setting "Use a generic response in public
+    # signup API error message"
+    #
+    # If somebody tries to sign up with an existing email address:
+    #
+    #     Before: Something went wrong, please try again later
+    #     After:  The user already exists.
+    #
+    # Auth0 disables this by default, to prevent attackers deducing the
+    # existence of an account by trying to sign up with the email address.
+    # This is a sensible default, because some of their customers are in areas
+    # where merely revealing the existence of a user account is a risk,
+    # e.g. anything financial or medical-related.
+    #
+    # For us, we prefer convenience over security: knowing that somebody
+    # has a library account isn't especially sensitive, and the more specific
+    # error message means users can reset their existing account password
+    # without emailing the library first.
+    enable_public_signup_user_exists_error = true
   }
 
   universal_login {


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/8202

This is the new error when you try to sign up with an already-used email address:

<img width="541" alt="Screenshot 2022-08-26 at 08 28 25" src="https://user-images.githubusercontent.com/301220/186848590-f534d014-3415-4d36-bf8e-61dd29ac53da.png">

