### PR TITLE
Improve the error message when somebody has multiple patron records

### DIFF
--- a/packages/apps/api/src/models/HttpError.ts
+++ b/packages/apps/api/src/models/HttpError.ts
@@ -21,6 +21,8 @@ export const clientResponseToHttpError = (response: ErrorResponse): HttpError =>
           return 401;
         case ResponseStatus.UserAlreadyExists:
           return 409;
+        case ResponseStatus.DuplicateUsers:
+          return 409;
         case ResponseStatus.MalformedRequest:
           return 400;
         case ResponseStatus.PasswordTooWeak:

--- a/packages/apps/auth0-database-scripts/src/create.ts
+++ b/packages/apps/auth0-database-scripts/src/create.ts
@@ -34,6 +34,11 @@ async function create(user: Auth0UserWithPassword) {
     user.email,
     user.password
   );
+
+  console.log(
+    `Received create patron response = ${JSON.stringify(createPatronResponse)}`
+  );
+
   if (createPatronResponse.status === ResponseStatus.UserAlreadyExists) {
     console.log('CREATE PATRON IN SIERRA ERRORS - USER ALREADY EXISTS');
     throw new ValidationError(user.email, userAlreadyExistsMessage);

--- a/packages/apps/auth0-database-scripts/src/create.ts
+++ b/packages/apps/auth0-database-scripts/src/create.ts
@@ -62,7 +62,7 @@ async function create(user: Auth0UserWithPassword) {
     } else if (
       createPatronResponse.message ===
       'Malformed or invalid Patron creation request ' +
-        '(cause: [{“code”:136,“specificCode”:3,“httpStatus”:400,“name”:“PIN is not valid”,“description”:“PIN is not valid : PIN too long”}])'
+        '(cause: [{"code":136,"specificCode":3,"httpStatus":400,"name":"PIN is not valid","description":"PIN is not valid : PIN too long"}])'
     ) {
       throw new ValidationError(user.email, 'Please use a shorter password.');
     } else {

--- a/packages/apps/auth0-database-scripts/src/get_user.ts
+++ b/packages/apps/auth0-database-scripts/src/get_user.ts
@@ -11,6 +11,7 @@ declare const configuration: {
 };
 
 async function getUser(email: string): Promise<Auth0User | undefined> {
+  console.log(`Entering getUser(${email})`);
   const apiRoot = configuration.API_ROOT;
   const clientKey = configuration.CLIENT_KEY;
   const clientSecret = configuration.CLIENT_SECRET;
@@ -24,6 +25,11 @@ async function getUser(email: string): Promise<Auth0User | undefined> {
     return patronRecordToUser(patronRecord);
   } else if (patronRecordResponse.status === ResponseStatus.NotFound) {
     return undefined;
+  } else if (patronRecordResponse.status === ResponseStatus.DuplicateUsers) {
+    throw new ValidationError(
+      email,
+      'There is an issue with this library account. To resolve this, please contact Library Enquiries (library@wellcomecollection.org)'
+    );
   } else {
     throw new Error(patronRecordResponse.message);
   }

--- a/packages/shared/identity-common/src/index.ts
+++ b/packages/shared/identity-common/src/index.ts
@@ -24,6 +24,7 @@ export function errorResponse(
     | ResponseStatus.NotFound
     | ResponseStatus.InvalidCredentials
     | ResponseStatus.UserAlreadyExists
+    | ResponseStatus.DuplicateUsers
     | ResponseStatus.MalformedRequest
     | ResponseStatus.PasswordTooWeak
     | ResponseStatus.QueryTimeout
@@ -75,6 +76,7 @@ export type ErrorResponse = {
     | ResponseStatus.NotFound
     | ResponseStatus.InvalidCredentials
     | ResponseStatus.UserAlreadyExists
+    | ResponseStatus.DuplicateUsers
     | ResponseStatus.MalformedRequest
     | ResponseStatus.PasswordTooWeak
     | ResponseStatus.QueryTimeout
@@ -87,6 +89,7 @@ export enum ResponseStatus {
   NotFound,
   InvalidCredentials,
   UserAlreadyExists,
+  DuplicateUsers,
   MalformedRequest,
   PasswordTooWeak,
   QueryTimeout,

--- a/packages/shared/sierra-client/src/HttpSierraClient.ts
+++ b/packages/shared/sierra-client/src/HttpSierraClient.ts
@@ -265,6 +265,29 @@ export default class HttpSierraClient implements SierraClient {
                   ResponseStatus.NotFound,
                   error
                 );
+
+              // The /find endpoint is meant to return a single user, but if Sierra
+              // finds multiple users it returns an error:
+              //
+              //    {
+              //      "code": 133,
+              //      "specificCode": 0,
+              //      "httpStatus": 409,
+              //      "name": "Internal server error",
+              //      "description": "Duplicate patrons found for the specified varFieldTag[z]."
+              //    }
+              //
+              case 409:
+                if (
+                  error.response.data.description ===
+                  'Duplicate patrons found for the specified varFieldTag[z].'
+                ) {
+                  return errorResponse(
+                    `There are duplicate patron records with email address [${email}]`,
+                    ResponseStatus.DuplicateUsers,
+                    error
+                  );
+                }
             }
           }
           return unhandledError(error);

--- a/packages/shared/sierra-client/tests/http-sierra-client.test.ts
+++ b/packages/shared/sierra-client/tests/http-sierra-client.test.ts
@@ -290,6 +290,47 @@ describe('HTTP sierra client', () => {
       expect(response.status).toBe(ResponseStatus.NotFound);
     });
 
+    it('returns DuplicateUsers when Sierra returns a 409', async () => {
+      mockSierraServer.use(
+        rest.get(routeUrls.find, (req, res, ctx) =>
+          res(
+            ctx.json({
+              code: 133,
+              description:
+                'Duplicate patrons found for the specified varFieldTag[z].',
+              httpStatus: 409,
+              name: 'Internal server error',
+              specificCode: 0,
+            }),
+            ctx.status(409)
+          )
+        )
+      );
+
+      const response = await client.getPatronRecordByEmail(email);
+      expect(response.status).toBe(ResponseStatus.DuplicateUsers);
+    });
+
+    it('returns UnknownError when Sierra returns an unrecognised 409', async () => {
+      mockSierraServer.use(
+        rest.get(routeUrls.find, (req, res, ctx) =>
+          res(
+            ctx.json({
+              code: 133,
+              description: 'Something else happened.',
+              httpStatus: 409,
+              name: 'Internal server error',
+              specificCode: 0,
+            }),
+            ctx.status(409)
+          )
+        )
+      );
+
+      const response = await client.getPatronRecordByEmail(email);
+      expect(response.status).toBe(ResponseStatus.UnknownError);
+    });
+
     it('returns an UnknownError when the api returns a 500', async () => {
       mockSierraServer.use(
         rest.get(routeUrls.find, (req, res, ctx) => res(ctx.status(500)))


### PR DESCRIPTION
Last night we saw a smattering of errors when somebody tried to sign up. The underlying issue wasn't that they already had a Sierra account (which we already handle correctly); it's that they had **two**. This should be impossible – we cleaned up all the duplicate accounts before launching the new user sign-in, and Auth0 should prevent this from happening – but it did, and we give a less than helpful error:

<img width="560" alt="Screenshot 2022-10-04 at 08 23 11" src="https://user-images.githubusercontent.com/301220/193759060-b4392cb8-d40f-4b69-b2b4-424587fff77f.png">

This patch adds a `DuplicateUsers` response status from the `getRecordByEmail()` method on the Sierra client, and then we can respond to it with a more actionable error message:

<img width="560" alt="Screenshot 2022-10-04 at 08 22 12" src="https://user-images.githubusercontent.com/301220/193758893-52104bb1-ca2f-489b-9199-6b2ea3608158.png">

This copy is based on a similar error which already works correctly on the sign-in screen:

<img width="549" alt="Screenshot 2022-10-04 at 08 22 03" src="https://user-images.githubusercontent.com/301220/193758881-58b2e8b8-4b49-4bef-a760-a50c6483d769.png">

I don't know why one error is in a red box and one is in inline text and I'm not going to spend the time to work it out; this should help the handful of users who are affected by this issue – and possibly prompt LE&E to work out where this is coming from.