### PR TITLE
If Sierra doesn't validate a password, log the user ID, not the email

### DIFF
--- a/packages/apps/auth0-database-scripts/src/login.ts
+++ b/packages/apps/auth0-database-scripts/src/login.ts
@@ -55,7 +55,10 @@ async function login(email: string, password: string): Promise<Auth0User> {
     password
   );
   if (validationResponse.status !== ResponseStatus.Success) {
-    throw new WrongUsernameOrPasswordError(email, invalidCredentialsMessage);
+    throw new WrongUsernameOrPasswordError(
+      `p${patronRecord.recordNumber}`,
+      invalidCredentialsMessage
+    );
   }
 
   if (hasImplicitlyVerifiedEmail(patronRecord)) {


### PR DESCRIPTION
When we throw a WrongUsernameOrPasswordError exception, this will appear as a "Failed Login (wrong password)" event in the Auth0 logs, e.g.

    {
      "date": "2023-01-12T13:45:57.493Z",
      "type": "fp",
      "description": "We don't recognise the email and/or password you entered. Please check your entry and try again.",
      "user_id": "auth0|…",
      "user_name": "example@example.com",
      …
    }

We throw it in two cases:

1.  Somebody enters an email address that we can't find in Sierra. There isn't a matching patron record, so we throw an error on L44.
2.  Somebody enters an email address that we can find in Sierra, but the password is incorrect, so we throw an error on L58.

Whatever we pass as the first argument to this exception will appear as the `user_id` in the Failed Login event, e.g.

    throw new WrongUsernameOrPasswordError('p1234567')
      => user_id: "auth0|p1234567"

    throw new WrongUsernameOrPasswordError('example@example.com')
      => user_id: "auth0|example@example.com"

Previously we were passing the email address in both cases, which means we can't distinguish between the two types of error.  This patch changes the logging slightly:

1.  If somebody enters an email address that we can't find in Sierra, we log the email address.
2.  If somebody enters an email address that is in Sierra but with the wrong password, we log the patron number.