### PR TITLE
Move to a HTTP healthcheck

### DIFF
--- a/infra/modules/ecs_service/target_group.tf
+++ b/infra/modules/ecs_service/target_group.tf
@@ -16,7 +16,9 @@ resource "aws_lb_target_group" "tcp" {
   deregistration_delay = 90
 
   health_check {
-    protocol = "TCP"
+    protocol = "HTTP"
+    path     = var.healthcheck_path
+    matcher  = "200"
   }
 }
 

--- a/infra/modules/ecs_service/variables.tf
+++ b/infra/modules/ecs_service/variables.tf
@@ -63,3 +63,8 @@ variable "load_balancer_arn" {
 variable "load_balancer_listener_port" {
   type = number
 }
+
+variable "healthcheck_path" {
+  type    = string
+  default = "/management/healthcheck"
+}


### PR DESCRIPTION
## What does this change?

This change follows https://github.com/wellcomecollection/catalogue-api/pull/747, using the endpoint provided there. 

See https://github.com/wellcomecollection/wellcomecollection.org/issues/10545 for the motivation for this change.

## How to test

- [ ] Deploy the code change to add the healthcheck endpoint to the requests service
- [ ] Update the stage environment first and observe the healthchecks behave as expected, tasks stay healthy

> [!NOTE]
> This project uses [terraform workspaces](https://developer.hashicorp.com/terraform/language/state/workspaces), and so attention needs to be paid when performing a stage deploy as this is different from elsewhere in our estate.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

No downtime during deployments resulting in a better experience for visitors to the site, and fewer errors that we cannot effectively respond to in the alerts channel.
