### PR TITLE
Add new StaffWithRestricted patron type

### DIFF
--- a/packages/shared/sierra-client/src/patron.ts
+++ b/packages/shared/sierra-client/src/patron.ts
@@ -22,7 +22,12 @@ export function toPatronRecord(response: PatronResponse): PatronRecord {
   };
 }
 
-export type Role = 'Reader' | 'Staff' | 'SelfRegistered' | 'Excluded';
+export type Role =
+  | 'Reader'
+  | 'Staff'
+  | 'SelfRegistered'
+  | 'Excluded'
+  | 'StaffWithRestricted';
 
 // You can find an up-to-date list of patronType codes and descriptions
 // in the Sierra API at: /v5/patrons/metadata
@@ -41,6 +46,8 @@ const patronTypeToRole = (patronType: number): Role => {
     case 19: // Exhibitions & Events
     case 22: // Conservation
       return 'Staff';
+    case 9: // Wellcome Collection Staff - including access to restricted items
+      return 'StaffWithRestricted';
     case 29: // Self Registered
       return 'SelfRegistered';
     case 6: // Excluded

--- a/packages/shared/sierra-client/tests/patron.test.ts
+++ b/packages/shared/sierra-client/tests/patron.test.ts
@@ -159,6 +159,7 @@ describe('toPatronRecord', () => {
   test.each([
     { patronType: 7, role: 'Reader' },
     { patronType: 8, role: 'Staff' },
+    { patronType: 9, role: 'StaffWithRestricted' },
     { patronType: 29, role: 'SelfRegistered' },
     { patronType: 6, role: 'Excluded' },
   ])('maps patronType $patronType to role $role', ({ patronType, role }) => {


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/identity/issues/400

In order to better restrict who has access to certain images, this change adds a new patron type for staff that should have access to restricted images (reducing this from all staff to only staff with this role).

This change will require an update to the IIIF API mappings here: https://github.com/wellcomecollection/iiif-builder/blob/main/src/AuthTest/AuthTest/Controllers/HomeController.cs#L38, requested here; https://wellcome.slack.com/archives/CBT40CMKQ/p1717676657432939. The new mapping should allow only `StaffWithRestricted` access to restricted images.

In addition this will require an update to the OpenAthens configuration that currently uses the `Staff` role from Auth0 to distinguish who should have access to certain journals. New configuration will need to include also the  `StaffWithRestricted` type.

## How to test

- [ ] Run the tests, do they pass?
- [ ] Deploy this change, ask a test user to login - is their patron type updated in Auth0?
- [ ] When the IIIF API changes have occurred, can only the new staff type get access to restricted images?

## How can we measure success?

Only staff users who need access to restricted images should have access to those images.

## Have we considered potential risks?

We are changing authentication for some users, but this should reduce permissions for staff rather than increase it. We should see if we can test this change on stage before releasing.