### PR TITLE
Adds an Auth0 client for the IIIF Image APIs

### DIFF
--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -303,6 +303,24 @@ resource "auth0_client" "smoke_test" {
   callbacks = []
 }
 
+resource "auth0_client" "iiif_image_api" {
+  name           = "IIIF Image API${local.environment_qualifier}"
+  app_type       = "regular_web"
+  is_first_party = true
+
+  # The password grant is used here as we consider this client running in CI
+  # secure enough to allow that.
+  grant_types = [
+    "authorization_code",
+    "refresh_token",
+    "implicit",
+    "client_credentials",
+  ]
+
+  allowed_logout_urls = local.iiif_image_api_config[terraform.workspace].allowed_logout_urls
+  callbacks           = local.iiif_image_api_config[terraform.workspace].callbacks
+}
+
 resource "auth0_client_grant" "smoke_test" {
   client_id = auth0_client.smoke_test.client_id
   audience  = auth0_resource_server.identity_api.identifier

--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -11,7 +11,6 @@ locals {
   stage_test_client_ids = concat(auth0_client.local_dev_client.*.client_id, [
     # Developer client ids can be added here
     "SrigIHZ3yXKlskZcdxJeytBuHqUUw7gn", // "David McCormick – Local Dev"
-    "NOx1lzM8ivV0ec0H3BMoxKGqXwJJF1em", // "Jamie Parkinson - Local Dev"
   ])
 
   # Terraform
@@ -42,6 +41,30 @@ locals {
   identity_v1_endpoint      = "https://${local.identity_v1_hostname}"
   identity_v1_docs_hostname = "docs.${local.identity_v1_hostname}"
   identity_v1_docs_endpoint = "https://${local.identity_v1_docs_hostname}"
+
+  # IIIF Image API client
+  iiif_image_api_config = {
+    "stage" = {
+      allowed_logout_urls = [
+        "https://localhost:5001/",
+        "https://auth-test.wellcomecollection.digirati.io/",
+        "https://iiif-test.wellcomecollection.org/auth/v2/access/2/eden/logout",
+      ],
+      callbacks = [
+        "https://localhost:5001/callback",
+        "https://auth-test.wellcomecollection.digirati.io/callback",
+        "https://iiif-test.wellcomecollection.org/auth/v2/access/eden/oauth2/callback",
+      ]
+    }
+    "prod" = {
+      allowed_logout_urls = [
+        "https://iiif.wellcomecollection.org/auth/v2/access/2/eden/logout",
+      ],
+      callbacks = [
+        "https://iiif.wellcomecollection.org/auth/v2/access/eden/oauth2/callback",
+      ]
+    }
+  }
 
   # Auth0
   auth0_hostname = nonsensitive("${local.hostname_prefix}${data.aws_ssm_parameter.hostname.value}")

--- a/infra/scoped/output.tf
+++ b/infra/scoped/output.tf
@@ -21,6 +21,10 @@ output "auth0_openathens_saml_idp_client_id" {
   value = auth0_client.openathens_saml_idp.client_id
 }
 
+output "auth0_iiif_image_api_client_id" {
+  value = auth0_client.iiif_image_api.client_id
+}
+
 # Environment variables (for CI / CD)
 
 output "ci_environment_variables" {

--- a/infra/scoped/provider.tf
+++ b/infra/scoped/provider.tf
@@ -37,6 +37,19 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "digirati"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::653428163053:role/digirati-developer"
+  }
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+provider "aws" {
   alias  = "dns"
   region = "eu-west-1"
 

--- a/infra/scoped/secrets.tf
+++ b/infra/scoped/secrets.tf
@@ -105,3 +105,19 @@ module "secrets_experience" {
     aws = aws.experience
   }
 }
+
+
+module "secrets_iiif_image_api" {
+  source = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.3.0"
+
+  # prefixed with wellcome as this account is controlled by digirati
+  # so namespacing to distinguish from any internal identity secrets
+  key_value_map = {
+    "wellcome/identity/${terraform.workspace}/iiif_image_api/auth0_client_id"     = auth0_client.iiif_image_api.client_id
+    "wellcome/identity/${terraform.workspace}/iiif_image_api/auth0_client_secret" = auth0_client.iiif_image_api.client_secret
+  }
+
+  providers = {
+    aws = aws.digirati
+  }
+}


### PR DESCRIPTION
## What does this change?

This change adds an Auth0 client for the staging and production tenants. This is required in order to allow the IIIF Image APIs to authenticate and authorize users to view restricted images.

This change creates secrets in the Digirati AWS account that can be consumed to configure the Image API service at the paths:

- `wellcome/identity/[stage|prod]/iiif_image_api/auth0_client_id`
- `wellcome/identity/[stage|prod]/iiif_image_api/auth0_client_secret`

Related to: https://github.com/wellcomecollection/identity/pull/403

Part of: https://github.com/wellcomecollection/platform/issues/5747 

> [!WARNING]
> This terraform change is applied, until this is merged other terraform changes are blocked.

### `terraform plan`

```console
Terraform will perform the following actions:

  # auth0_client.iiif_image_api will be created
  + resource "auth0_client" "iiif_image_api" {
      + allowed_logout_urls                 = [
          + "https://iiif.wellcomecollection.org/auth/v2/access/2/eden/logout",
        ]
      + app_type                            = "regular_web"
      + callbacks                           = [
          + "https://iiif.wellcomecollection.org/auth/v2/access/eden/oauth2/callback",
        ]
      + client_id                           = (known after apply)
      + client_secret                       = (sensitive value)
      + custom_login_page_on                = (known after apply)
      + grant_types                         = [
          + "authorization_code",
          + "refresh_token",
          + "implicit",
          + "client_credentials",
        ]
      + id                                  = (known after apply)
      + is_first_party                      = true
      + is_token_endpoint_ip_header_trusted = (known after apply)
      + name                                = "IIIF Image API"
      + oidc_conformant                     = (known after apply)
      + signing_keys                        = (sensitive value)
      + token_endpoint_auth_method          = (known after apply)
    }

  # module.secrets_iiif_image_api.aws_secretsmanager_secret.secret["wellcome/identity/prod/iiif_image_api/auth0_client_id"] will be created
  + resource "aws_secretsmanager_secret" "secret" {
      + arn                            = (known after apply)
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + name                           = "wellcome/identity/prod/iiif_image_api/auth0_client_id"
      + name_prefix                    = (known after apply)
      + policy                         = (known after apply)
      + recovery_window_in_days        = 30
      + tags_all                       = {
          + "Environment"               = "prod"
          + "ManagedBy"                 = "Terraform"
          + "Project"                   = "Identity"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/identity/tree/main/infra/scoped"
        }
    }

  # module.secrets_iiif_image_api.aws_secretsmanager_secret.secret["wellcome/identity/prod/iiif_image_api/auth0_client_secret"] will be created
  + resource "aws_secretsmanager_secret" "secret" {
      + arn                            = (known after apply)
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + name                           = "wellcome/identity/prod/iiif_image_api/auth0_client_secret"
      + name_prefix                    = (known after apply)
      + policy                         = (known after apply)
      + recovery_window_in_days        = 30
      + tags_all                       = {
          + "Environment"               = "prod"
          + "ManagedBy"                 = "Terraform"
          + "Project"                   = "Identity"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/identity/tree/main/infra/scoped"
        }
    }

  # module.secrets_iiif_image_api.aws_secretsmanager_secret_version.secret["wellcome/identity/prod/iiif_image_api/auth0_client_id"] will be created
  + resource "aws_secretsmanager_secret_version" "secret" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + secret_id      = (known after apply)
      + secret_string  = (sensitive value)
      + version_id     = (known after apply)
      + version_stages = (known after apply)
    }

  # module.secrets_iiif_image_api.aws_secretsmanager_secret_version.secret["wellcome/identity/prod/iiif_image_api/auth0_client_secret"] will be created
  + resource "aws_secretsmanager_secret_version" "secret" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + secret_id      = (known after apply)
      + secret_string  = (sensitive value)
      + version_id     = (known after apply)
      + version_stages = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.
```

## How to test

The Digirati test client should allow users to sign-in without error: https://tomcrane.github.io/iiif-auth-client/?manifest=https://iiif.wellcomecollection.org/presentation/b20146267

## How can we measure success?

Users for the Wellcome Collection with the appropriate roles can view restricted images.

## Have we considered potential risks?

We must be careful that this change does not modify or delete any existing resources! The terraform apply indicates this is not the case.

