### PR TITLE
Add IIIF Image API client to Sierra database connection

### DIFF
--- a/infra/scoped/auth0-connection.tf
+++ b/infra/scoped/auth0-connection.tf
@@ -6,6 +6,7 @@ resource "auth0_connection" "sierra" {
     auth0_client.api_gateway_identity.id, # Required to allow the Lambda API client credentials to operate on the connection
     auth0_client.identity_web_app.id,
     auth0_client.openathens_saml_idp.id,
+    auth0_client.iiif_image_api.id,
     auth0_client.smoke_test.id],
     terraform.workspace == "stage" ? local.stage_test_client_ids : [],
   )


### PR DESCRIPTION
## What does this change?

This change follows https://github.com/wellcomecollection/identity/pull/405 and is required to allow this client to authenticate Sierra users (oops)!

Part of: https://github.com/wellcomecollection/platform/issues/5747 

> [!WARNING]
> This terraform change is applied, until this is merged other terraform changes are blocked.

## How to test

The test app https://tomcrane.github.io/iiif-auth-client/?manifest=https://iiif.wellcomecollection.org/presentation/b20146267,  doesn't lead you to an error with `?error=invalid_request&error_description=no%20connections%20enabled%20for%20the%20client` in the URL.

## How can we measure success?

Moving closer to getting access to restricted items for users with the right roles.

## Have we considered potential risks?

This change impacts only existing as yet to be used app clients, so should not impact other users.
