### PR TITLE
Add callback and logout URLs for IIIF image app

### DIFF
--- a/infra/scoped/locals.tf
+++ b/infra/scoped/locals.tf
@@ -49,19 +49,23 @@ locals {
         "https://localhost:5001/",
         "https://auth-test.wellcomecollection.digirati.io/",
         "https://iiif-test.wellcomecollection.org/auth/v2/access/2/eden/logout",
+        "https://iiif-test.wellcomecollection.org/auth/v2/access/2/restrictedlogin/logout",
       ],
       callbacks = [
         "https://localhost:5001/callback",
         "https://auth-test.wellcomecollection.digirati.io/callback",
         "https://iiif-test.wellcomecollection.org/auth/v2/access/eden/oauth2/callback",
+        "https://iiif-test.wellcomecollection.org/auth/v2/access/restrictedlogin/oauth2/callback",
       ]
     }
     "prod" = {
       allowed_logout_urls = [
         "https://iiif.wellcomecollection.org/auth/v2/access/2/eden/logout",
+        "https://iiif.wellcomecollection.org/auth/v2/access/2/restrictedlogin/logout",
       ],
       callbacks = [
         "https://iiif.wellcomecollection.org/auth/v2/access/eden/oauth2/callback",
+        "https://iiif.wellcomecollection.org/auth/v2/access/restrictedlogin/oauth2/callback",
       ]
     }
   }


### PR DESCRIPTION
## What does this change?

This change adds the correct callback and logout URLs for the IIIF Image application in Auth0 that allows restricted logins to occur.

Part of https://github.com/wellcomecollection/platform/issues/5747

See https://wellcome.slack.com/archives/CBT40CMKQ/p1723462603970219?thread_ts=1720700716.827569&cid=CBT40CMKQ

### `terraform plan`

```
Terraform will perform the following actions:

  # auth0_client.iiif_image_api will be updated in-place
  ~ resource "auth0_client" "iiif_image_api" {
      ~ allowed_logout_urls                 = [
            "https://iiif.wellcomecollection.org/auth/v2/access/2/eden/logout",
          + "https://iiif.wellcomecollection.org/auth/v2/access/2/restrictedlogin/logout",
        ]
        id                                  = "REDACTED"
        name                                = "IIIF Image API"
        # (19 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

> [!NOTE]
> This change has already been applied in the staging and production tenants.

## How to test

- [ ] Review the the Auth0 configuration after applying, have the updates occurred?

## How can we measure success?

The restricted login work is enabled by this change.

## Have we considered potential risks?

If these URLs are incorrect or for a bad source that could cause issues, but these have been checked by Digirati hopefully mitigating that risk.
