### PR TITLE
add auth0 permissions for buildkite

### DIFF
--- a/infra/scoped/auth0-actions.tf
+++ b/infra/scoped/auth0-actions.tf
@@ -5,7 +5,7 @@ resource "auth0_action" "add_custom_claims" {
 
   supported_triggers {
     id      = "post-login"
-    version = "v2"
+    version = "v3"
   }
 
   lifecycle {

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -169,6 +169,8 @@ resource "auth0_client_grant" "buildkite" {
     "read:log_streams",
     "update:log_streams",
     "delete:log_streams",
+    "read:connections_options", # https://auth0.com/docs/troubleshoot/product-lifecycle/deprecations-and-migrations EOL April 24, 2025
+    "update:connections_options"
   ]
 }
 
@@ -304,9 +306,10 @@ resource "auth0_client" "smoke_test" {
 }
 
 resource "auth0_client" "iiif_image_api" {
-  name           = "IIIF Image API${local.environment_qualifier}"
-  app_type       = "regular_web"
-  is_first_party = true
+  name                          = "IIIF Image API${local.environment_qualifier}"
+  app_type                      = "regular_web"
+  is_first_party                = true
+  organization_require_behavior = "no_prompt"
 
   # The password grant is used here as we consider this client running in CI
   # secure enough to allow that.

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -17,12 +17,12 @@ resource "auth0_client" "local_dev_client" {
 
   callbacks = [
     for url in auth0_client.identity_web_app.callbacks :
-    replace(url, local.wellcome_collection_site_uri, "http://localhost:3000")
+    replace(url, local.wellcome_collection_site_uri, "http://localhost:3003")
   ]
 
   allowed_logout_urls = [
     for url in auth0_client.identity_web_app.allowed_logout_urls :
-    replace(url, local.wellcome_collection_site_uri, "http://localhost:3000")
+    replace(url, local.wellcome_collection_site_uri, "http://localhost:3003")
   ]
 
   lifecycle {

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -22,7 +22,7 @@ resource "auth0_client" "local_dev_client" {
 
   allowed_logout_urls = [
     for url in auth0_client.identity_web_app.allowed_logout_urls :
-    replace(url, local.wellcome_collection_site_uri, "http://localhost:3003")
+    replace(url, local.wellcome_collection_site_uri, "http://localhost:3000")
   ]
 
   lifecycle {

--- a/infra/scoped/auth0-client.tf
+++ b/infra/scoped/auth0-client.tf
@@ -15,15 +15,27 @@ resource "auth0_client" "local_dev_client" {
 
   grant_types = auth0_client.identity_web_app.grant_types
 
-  callbacks = [
-    for url in auth0_client.identity_web_app.callbacks :
-    replace(url, local.wellcome_collection_site_uri, "http://localhost:3003")
-  ]
+  callbacks = concat(
+    [
+      for url in auth0_client.identity_web_app.callbacks :
+      replace(url, local.wellcome_collection_site_uri, "http://localhost:3003")
+    ],
+    [
+      for url in auth0_client.identity_web_app.callbacks :
+      replace(url, local.wellcome_collection_site_uri, "https://www-dev.wellcomecollection.org")
+    ]
+  )
 
-  allowed_logout_urls = [
-    for url in auth0_client.identity_web_app.allowed_logout_urls :
-    replace(url, local.wellcome_collection_site_uri, "http://localhost:3000")
-  ]
+  allowed_logout_urls = concat(
+    [
+      for url in auth0_client.identity_web_app.allowed_logout_urls :
+      replace(url, local.wellcome_collection_site_uri, "http://localhost:3000")
+    ],
+    [
+      for url in auth0_client.identity_web_app.allowed_logout_urls :
+      replace(url, local.wellcome_collection_site_uri, "https://www-dev.wellcomecollection.org")
+    ]
+  )
 
   lifecycle {
     ignore_changes = [

--- a/infra/scoped/auth0-logs.tf
+++ b/infra/scoped/auth0-logs.tf
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_event_bus" "auth0_logs" {
 resource "aws_cloudwatch_event_rule" "auth0_logs" {
   name        = "capture-auth0-errors-${terraform.workspace}"
   description = "Capture Auth0 errors that indicate unexpected behaviour"
-  is_enabled  = true
+  state       = "ENABLED"
 
   event_bus_name = aws_cloudwatch_event_bus.auth0_logs.name
 

--- a/infra/scoped/backend.tf
+++ b/infra/scoped/backend.tf
@@ -1,6 +1,8 @@
 terraform {
   backend "s3" {
-    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    assume_role = {
+      role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    }
 
     bucket         = "identity-remote-state"
     key            = "terraform.tfstate"

--- a/infra/scoped/cloudwatch.tf
+++ b/infra/scoped/cloudwatch.tf
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_event_rule" "patron_deletion_tracker" {
   name                = "patron-deletion-tracker-${terraform.workspace}"
   description         = "Triggers the Patron deletion tracker lambda"
   schedule_expression = "rate(1 day)"
-  is_enabled          = true
+  state               = "ENABLED"
 }
 
 resource "aws_cloudwatch_event_target" "patron_deletion_tracker" {

--- a/infra/scoped/terraform.tf
+++ b/infra/scoped/terraform.tf
@@ -89,8 +89,8 @@ data "terraform_remote_state" "monitoring" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/monitoring.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
   }
 }

--- a/infra/scoped/terraform.tf
+++ b/infra/scoped/terraform.tf
@@ -30,7 +30,9 @@ data "terraform_remote_state" "identity_static" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    assume_role = {
+      role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+    }
 
     bucket = "identity-static-remote-state"
     key    = "terraform.tfstate"
@@ -42,7 +44,9 @@ data "terraform_remote_state" "infra_critical" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/platform-infrastructure/shared.tfstate"
@@ -54,7 +58,9 @@ data "terraform_remote_state" "catalogue_api_shared" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::756629837203:role/catalogue-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::756629837203:role/catalogue-read_only"
+    }
 
     bucket = "wellcomecollection-catalogue-infra-delta"
     key    = "terraform/catalogue/api/shared.tfstate"
@@ -66,7 +72,9 @@ data "terraform_remote_state" "accounts_identity" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/aws-account-infrastructure/identity.tfstate"
@@ -78,7 +86,9 @@ data "terraform_remote_state" "monitoring" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/monitoring.tfstate"
     region   = "eu-west-1"


### PR DESCRIPTION
## What does this change?

Deprecation warning, see https://wellcome.slack.com/archives/CQ720BG02/p1738588477106949

## How to test

Apply to stage workspace and see whether the deprecation warning stop popping up in the alert channel

## How can we measure success?

The deprecation warning stop popping up in the alert channel

## Have we considered potential risks?

This is set up with separate stage/prod workspace so we can check things are fine before applying to prod

```
Terraform will perform the following actions:

  # auth0_client_grant.buildkite will be updated in-place
  ~ resource "auth0_client_grant" "buildkite" {
        id        = "cgr_mAD3ICX6y2cGDpLb"
      ~ scope     = [
            # (71 unchanged elements hidden)
            "delete:log_streams",
          + "read:connections_options",
          + "update:connections_options",
        ]
        # (2 unchanged attributes hidden)
    }

  # module.api_lambda.aws_lambda_function.main will be updated in-place
  ~ resource "aws_lambda_function" "main" {
        id                             = "identity-api-stage"
        tags                           = {
            "name" = "identity-authorizer-stage"
        }
        # (28 unchanged attributes hidden)

      ~ environment {
          # Warning: this attribute value will be marked as sensitive and will not
          # display in UI output after applying this change. The value is unchanged.
          ~ variables = (sensitive value)
        }

        # (4 unchanged blocks hidden)
    }

  # module.patron_deletion_tracker_lambda.aws_lambda_function.main will be updated in-place
  ~ resource "aws_lambda_function" "main" {
        id                             = "patron-deletion-tracker-stage"
        tags                           = {
            "name" = "patron-deletion-tracker-stage"
        }
        # (28 unchanged attributes hidden)

      ~ environment {
          # Warning: this attribute value will be marked as sensitive and will not
          # display in UI output after applying this change. The value is unchanged.
          ~ variables = (sensitive value)
        }

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
```
