### PR TITLE
Update the Auth0 deploy CLI to version 8

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/docker/library/node:20
 
 SHELL ["/bin/bash", "-ox", "pipefail", "-c"]
 
-ARG A0DEPLOY_VERSION=7.12.2
+ARG A0DEPLOY_VERSION=8.6.2
 RUN apt-get update && \
     apt-get install -y git zip findutils python3 python3-pip jq moreutils && \
     rm -rf /var/lib/apt/lists/* && \

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -1,7 +1,7 @@
 
 services:
   app:
-    image: 770700576653.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity-build:2025-02-03
+    image: 770700576653.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity-build:2025-03-10
     volumes:
       - ../:/app
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Attempting to resolve a deployment issue that seems to have been introduced in version 7 that stops deployments from working.

https://community.auth0.com/t/bad-request-query-validation-error-additional-properties-not-allowed-paginate/182902/3

See: https://wellcome.slack.com/archives/C02ANCYL90E/p1741604428289289

## What does this change?

This upgrades the deployment CLI for Auth0 to work around the issue mentioned above.

In order to apply this change it was necessary to build and push a new image to ECR:

```shell
# Sign into ECR for identity to allow pushing image
aws ecr get-login-password --profile identity-developer | \
  docker login --username AWS --password-stdin 770700576653.dkr.ecr.eu-west-1.amazonaws.com
# Sign into ECR public for identity to allow pulling from ECR public for base image
aws ecr-public get-login-password --region us-east-1 --profile identity-developer | \
  docker login --username AWS --password-stdin public.ecr.aws 

# Build the image targeting the correct platform
docker build . -t 770700576653.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity-build:2025-03-10 \
  --platform linux/amd64 --provenance=false
# Push the image up
docker push 770700576653.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity-build:2025-03-10
```

## How to test

- [ ] Test deployment in stage, does it succeed?

## How can we measure success?

Deployments in identity can proceed.

## Have we considered potential risks?

The breaking changes in v8 do not seem to intersect with anything we're doing: https://github.com/auth0/auth0-deploy-cli/blob/v8.0.0/docs/v8_MIGRATION_GUIDE.md, so this should be safe. 

There is a risk of breaking identity deployments further, we should test this in stage.

